### PR TITLE
Simplify paradigm to sketch mapping

### DIFF
--- a/build.py
+++ b/build.py
@@ -40,10 +40,10 @@ SPEC_FILE = os.path.join(SCRIPT_DIR, "reacher.spec")
 
 PARADIGMS = ("fr", "pr", "vi", "omission", "pavlovian")
 PARADIGM_TO_SKETCH = {
-    "fr": "operant_FR",
-    "pr": "operant_PR",
-    "vi": "operant_VI",
-    "omission": "operant_OMISSION",
+    "fr": "fr",
+    "pr": "pr",
+    "vi": "vi",
+    "omission": "omission",
     "pavlovian": "pavlovian",
 }
 BOARDS = ("uno", "mega")


### PR DESCRIPTION
## Summary
Simplified the `PARADIGM_TO_SKETCH` mapping by removing the "operant_" prefix from sketch names for operant paradigms.

## Changes
- Updated paradigm-to-sketch mappings to use simplified names:
  - `"fr": "operant_FR"` → `"fr": "fr"`
  - `"pr": "operant_PR"` → `"pr": "pr"`
  - `"vi": "operant_VI"` → `"vi": "vi"`
  - `"omission": "operant_OMISSION"` → `"omission": "omission"`
- Kept `"pavlovian": "pavlovian"` unchanged

## Details
This change aligns the sketch naming convention to be consistent across all paradigm types, using the paradigm identifier directly as the sketch name rather than prefixing operant paradigms with "operant_". This simplifies the mapping and likely reflects a refactoring of the sketch file naming structure.

https://claude.ai/code/session_01U9syM4993rQa8KGKnu6ajD