### PR TITLE
bug: infusion counter not updating for FR paradigm due to PUMP_1 device name mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.0.0-beta.4] - 2026-06-15
+
+### Fixed
+- Infusion counter and primary-pump arm-state sync now recognise `PUMP_1` emitted by operant-paradigm firmware (FR/PR/VI/Omission) alongside legacy `PUMP`; real operant sessions silently skipped the counter increment while demo mode (which already used `PUMP_1`) worked correctly ([#45](https://github.com/Otis-Lab-MUSC/labrynth/issues/45))
+
+---
+
 ## [3.0.0-alpha.1] - 2026-06-12
 
 _First release of the **v3** line and the first cut under the new semver

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build orchestrator, React frontend, and terminal CLI for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.0--beta.3-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
+[![Version](https://img.shields.io/badge/version-3.0.0--beta.4-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
 [![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labrynth"
-version = "3.0.0-beta.3"
+version = "3.0.0-beta.4"
 description = "Labrynth application shell — build orchestrator and frontend"
 requires-python = ">=3.10"
 dependencies = [
-    "reacher>=3.0.0b2",
+    "reacher>=3.0.0b3",
     "pyinstaller>=6.0",
 ]
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labrynth-frontend",
   "private": true,
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/hooks/useSessionWebSockets.ts
+++ b/web/src/hooks/useSessionWebSockets.ts
@@ -21,6 +21,7 @@ const DEVICE_TO_UI_KEY: Record<string, string> = {
   CUE: "primaryCue",
   CUE2: "secondaryCue",
   PUMP: "primaryPump",
+  PUMP_1: "primaryPump",
   PUMP2: "secondaryPump",
   LASER: "laser",
   LICK: "lickCircuit",

--- a/web/src/store/useSessionStore.ts
+++ b/web/src/store/useSessionStore.ts
@@ -262,7 +262,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       if (!sess || sess.state !== "running") return s;
       const next = new Map(s.sessions);
       const infusionCount =
-        event.device === "PUMP" && event.event === "INFUSION"
+        (event.device === "PUMP" || event.device === "PUMP_1") && event.event === "INFUSION"
           ? sess.infusionCount + 1
           : sess.infusionCount;
       const pressCount =


### PR DESCRIPTION
## Intent
Operant-paradigm firmware emits `device: "PUMP_1"` for FR/PR/VI/Omission sessions, but
the frontend's `DEVICE_TO_UI_KEY` map and `useSessionStore` infusion counter only
recognised `"PUMP"` and `"PUMP2"`. This caused the infusion counter to silently not
increment during any operant session, even though the underlying events were reaching the
timeline correctly.

## Approach the AI took
Added `PUMP_1 -> "primaryPump"` to the `DEVICE_TO_UI_KEY` map in
`useSessionWebSockets.ts` and extended the infusion counter condition in
`useSessionStore.ts` to accept both `"PUMP"` and `"PUMP_1"`. Versioned as
v3.0.0-beta.4 with `reacher>=3.0.0b3` dependency pin; CHANGELOG promoted accordingly.

## Risk
FILL IN: <describe what could go wrong or break>

## Not tested
FILL IN: <describe what was not covered by manual or automated testing>

Closes #45