### PR TITLE
Labrynth UI: update tutorial and documentation post-updates

### DIFF
--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -11,11 +11,14 @@ Usage:
     python scripts/bump-version.py --print-reacher-ref   # print the reacher git ref from the stored pin
 
 Labrynth carries its own version (``pyproject.toml`` + ``web/package.json`` +
-the README badge) *and* a cross-repo pin on the ``reacher`` backend it ships.
-Those are independent axes:
+the root and ``web/`` README badges + the demo mock's reported backend version)
+*and* a cross-repo pin on the ``reacher`` backend it ships. Those are
+independent axes:
 
   - The plain ``<version>`` / ``--check`` forms manage Labrynth's own version.
-    The README badge stores it shields.io-escaped (``-`` -> ``--``).
+    The README badges store it shields.io-escaped (``-`` -> ``--``); the demo
+    mock (``web/src/api/{demoClient,mock}.ts``) stores it as a plain string so
+    the hosted demo never reports a stale build.
   - ``--reacher-pin <semver>`` manages the ``reacher>=X.Y.Z`` dependency,
     normalizing the semver to its PEP 440 form (``3.0.0-alpha.1`` -> ``3.0.0a1``)
     so the pin pip actually resolves is never hand-derived. Bump this to ship a
@@ -128,6 +131,30 @@ REGEX_FILES: list[tuple[Path, str, str, "callable", str]] = [
         r"\g<1>{version}\3",
         shields,
         "README.md (badge)",
+    ),
+    (
+        ROOT / "web" / "README.md",
+        r"(shields\.io/badge/version-)(.+?)(-blue)",
+        r"\g<1>{version}\3",
+        shields,
+        "web/README.md (badge)",
+    ),
+    # Demo mode's mock health check reports a backend version string; stamp it
+    # in lockstep with the app version so the hosted demo never reports a stale
+    # build. Each file has exactly one `version:` literal.
+    (
+        ROOT / "web" / "src" / "api" / "demoClient.ts",
+        r'(version:\s*")([^"]+)(")',
+        r"\g<1>{version}\3",
+        identity,
+        "web/src/api/demoClient.ts (demo version)",
+    ),
+    (
+        ROOT / "web" / "src" / "api" / "mock.ts",
+        r'(version:\s*")([^"]+)(")',
+        r"\g<1>{version}\3",
+        identity,
+        "web/src/api/mock.ts (demo version)",
     ),
 ]
 

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 **Browser-based experiment control interface for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-2.0.0-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
+[![Version](https://img.shields.io/badge/version-3.0.0--beta.5-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
 [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -14,7 +14,7 @@ export class DemoMachineApiClient extends MachineApiClient {
 
   // --- Health ---
   probeHealth = async () =>
-    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "2.1.0", active_sessions: 0 });
+    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.0-beta.5", active_sessions: 0 });
 
   // --- Sessions ---
   listSessions = () => mock.listSessions() as ReturnType<MachineApiClient["listSessions"]>;

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -165,7 +165,7 @@ export const uploadFirmware = async (id: string, paradigm: string, board: string
     board,
     firmware_info: {
       sketch: paradigm,
-      version: "2.1.0",
+      version: "3.0.0-beta.5",
       baud_rate: 115200,
       desc: `Demo ${paradigm.toUpperCase()} firmware`,
     },

--- a/web/src/components/tutorial/help/content.ts
+++ b/web/src/components/tutorial/help/content.ts
@@ -39,7 +39,13 @@ export const HELP_CONTENT: HelpSection[] = [
         id: "session.machines",
         title: "Device Management",
         content:
-          "The Manage Devices section lets you pair and manage remote devices. Use a 6-digit pairing code displayed on the remote device, scan for devices on your local network, or add a machine manually by URL and API key.",
+          "The Manage Devices section lets you pair and manage remote REACHER machines. Use a 6-digit pairing code displayed on the remote device, pick a device discovered automatically via mDNS on your local network, or add a machine manually by URL and API key. Paired machines run in proxy mode: every call routes through your local server, which holds the remote API key — the browser never sees it. This lets you drive several hosts from one window.",
+      },
+      {
+        id: "session.suspend",
+        title: "Idle Suspend & Recovery",
+        content:
+          "To conserve resources, the REACHER server suspends itself when no client has been connected for an extended period. A full-screen \"Session Timed Out\" overlay then appears with Reconnect and Export Session Data buttons. Session data is preserved on suspend, and the server process only fully shuts down after a longer idle window with no reconnection. Click Reconnect to reload and resume. If a session was actively running, reloading discards its in-memory data — export first when prompted.",
       },
     ],
   },
@@ -53,6 +59,12 @@ export const HELP_CONTENT: HelpSection[] = [
         title: "Session Presets",
         content:
           "Session presets pre-configure all settings in one click: hardware arm states, paradigm parameters, and limits. Presets are filtered by the detected paradigm. After selecting a preset, you can still adjust individual settings before starting.",
+      },
+      {
+        id: "configuration.pavlovian",
+        title: "Pavlovian Presets & Cards",
+        content:
+          "Pavlovian paradigms use their own presets (e.g., Pavlovian Acquisition and Reversal). Their preset cards surface Pavlovian-specific values — CS+/CS− counts, CS+ reward probability, and trace interval — in place of lever ratios and contingencies, since Pavlovian sessions have no lever-based reward routing. Apply the preset, then fine-tune in the dedicated Pavlovian settings panel before starting.",
       },
       {
         id: "configuration.paradigm",
@@ -158,13 +170,13 @@ export const HELP_CONTENT: HelpSection[] = [
         id: "data.fileconfig",
         title: "File Configuration",
         content:
-          "Set the output filename and destination directory on the Session Configuration page before starting. Click Save Config to persist these to the backend. If left blank, the system defaults to a timestamp-based filename saved to ~/Downloads.",
+          "Set the output filename and destination directory on the Session Configuration page before starting. Click Save Config to persist these to the backend. For a local session, use Browse to pick a folder; for a paired remote machine there's no Browse — type a path on the remote host, where the data lives. If left blank, data defaults to a timestamp-based filename in the session host's ~/Downloads. The engine also streams every event to an append-only on-disk log under ~/REACHER/LOG/ on the host, so raw data survives even if export fails.",
       },
       {
         id: "data.export",
         title: "Auto-Export",
         content:
-          "When a session ends (manually or by reaching its limit), data is automatically saved. The ZIP contains:\n\n- Behavior events (CSV with device, event, timestamps)\n- Frame timestamps (for microscope sync)\n- Session metadata (paradigm, settings, limits, counts)\n\nThe save path is shown on the Session page after the session stops.",
+          "When a session ends (manually or by reaching its limit), data is automatically saved. The ZIP contains:\n\n- Behavior events (CSV with device, event, timestamps)\n- Frame timestamps (for microscope sync)\n- Session metadata (paradigm, settings, limits, counts)\n\nThe save path is shown on the Session page after the session stops. For a remote machine the ZIP is written on the remote host, not your local computer.",
       },
     ],
   },

--- a/web/src/components/tutorial/tours/firstSession.ts
+++ b/web/src/components/tutorial/tours/firstSession.ts
@@ -98,7 +98,7 @@ export function firstSessionTour(): TutorialStep[] {
       target: "machine-management",
       title: "Device Management",
       content:
-        "Expand this section to pair remote devices on your network. You can enter a 6-digit pairing code, scan for discovered devices, or add a machine manually by URL.",
+        "Expand this section to pair remote REACHER machines on your network. Enter a 6-digit pairing code, pick a device discovered automatically via mDNS, or add one manually by URL. Paired machines run in proxy mode — their API keys stay on your local server and never reach the browser, so you can drive several hosts from one window.",
       placement: "bottom",
       section: "Getting Started",
     },
@@ -156,7 +156,7 @@ export function firstSessionTour(): TutorialStep[] {
       target: "preset-card",
       title: "Preset Details",
       content:
-        "The preset card shows session limits, the device table with arm/disarm toggles for each piece of hardware, and the configured parameters. Review and adjust, then click Apply Preset to push all settings to the session at once.",
+        "The preset card shows session limits, the device table with arm/disarm toggles for each piece of hardware, and the configured parameters. Review and adjust, then click Apply Preset to push all settings to the session at once. A Pavlovian preset card surfaces its CS+/CS− counts, CS+ reward probability, and trace interval in place of lever contingencies.",
       placement: "bottom",
       interactive: true,
       section: "Configuration",
@@ -167,7 +167,7 @@ export function firstSessionTour(): TutorialStep[] {
       target: "paradigm-settings",
       title: "Paradigm Settings",
       content:
-        "Configure paradigm-specific parameters here. Try adjusting the values — they'll be sent to the Arduino when you start.",
+        "Configure paradigm-specific parameters here. Try adjusting the values — they'll be sent to the Arduino when you start. Pavlovian sessions get a dedicated panel for CS+/CS− reward probabilities and counts, trace interval, tone-pulse timing, and the ITI distribution.",
       placement: "bottom",
       interactive: true,
       section: "Configuration",
@@ -268,8 +268,8 @@ export function firstSessionTour(): TutorialStep[] {
       target: "file-config",
       title: "File Configuration",
       content:
-        "Set a filename and destination folder for your exported data before starting the session. If left blank, the system defaults to a timestamp-based filename saved to your machine's Downloads folder. " +
-        "The Python engine also appends every behavioral event to an on-disk log (~/REACHER/LOG/) in real time, so your data is safe even if the export step fails.",
+        "Set a filename and destination folder for your exported data before starting the session. For a local session, use Browse to pick a folder; for a paired remote machine there's no Browse — type a path on the remote host, where the data actually lives. " +
+        "If left blank, data exports to a timestamp-based file in the session host's Downloads folder. Either way, the engine also appends every behavioral event to an on-disk log (~/REACHER/LOG/) on the session host in real time, so your data is safe even if the export step fails.",
       placement: "bottom",
       interactive: true,
       section: "Data",
@@ -281,7 +281,7 @@ export function firstSessionTour(): TutorialStep[] {
       target: "monitor-heading",
       title: "Auto-Export",
       content:
-        "When the session ends — whether manually stopped or by reaching its limit — data is automatically saved to the configured destination (or ~/Downloads by default). The save path appears on the Session page.",
+        "When the session ends — whether manually stopped or by reaching its limit — data is automatically saved to the configured destination (or the session host's Downloads folder by default). The save path appears on the Session page. For a remote machine the files are written on the remote host, not your local computer.",
       placement: "bottom",
       section: "Data",
     },
@@ -295,6 +295,16 @@ export function firstSessionTour(): TutorialStep[] {
       content:
         "The terminal shows log messages: connection events, errors, upload progress, and session state changes. Click to expand.",
       placement: "top",
+      section: "Complete",
+    },
+    {
+      id: "first-session-19b",
+      panel: null,
+      target: "",
+      title: "Idle Suspend & Recovery",
+      content:
+        "To save resources, the REACHER server suspends itself when no client stays connected for a while. A full-screen \"Session Timed Out\" overlay then appears with Reconnect and Export Session Data buttons — your data is preserved, and the server only fully shuts down if you don't reconnect in time. Reconnecting picks the session back up where you left off.",
+      placement: "center",
       section: "Complete",
     },
     {


### PR DESCRIPTION
## Intent
Recent UI changes (proxy/multi-machine save behavior, the export-destination fix,
Pavlovian preset cards, the server-suspend overlay) shipped without updating the
in-app guided tour, Help panel, or online demo — so first-time users were walked
through stale, sometimes wrong flows. This brings every user-facing tutorial/doc
surface back in line with the current UI.

## Approach the AI took
- **Tour (`firstSession.ts`):** rewrote export-destination copy (steps 17/18) for the
  local-vs-remote/proxy distinction — data lives on the *session host*, not "your
  machine"; expanded Device Management (3b) to cover mDNS + proxy mode; added an
  idle-suspend/watchdog step; added Pavlovian-aware copy to the preset/paradigm steps.
- **Help (`content.ts`):** new "Idle Suspend & Recovery" and "Pavlovian Presets &
  Cards" sections; updated Data & Export for remote-host saves.
- **Demo + docs:** refreshed the stale demo mock backend version (`2.1.0`) and the
  `web/README` badge (`2.0.0`), then wired both into `bump-version.py` so they stamp
  with the app version and are covered by `--check`.
- Verified the `~/REACHER/LOG`, `~/Downloads` default, and UNO/Mega board claims
  against the reacher backend before editing — all correct, kept as-is.

## Risk
Copy/string + build-tooling changes only — no runtime logic paths altered, so
low risk. The new `bump-version.py` regexes assume each demo file has exactly one
`version:` literal (true today); a future second literal could mis-stamp. Repo-wide
ESLint is pre-existing broken (no `eslint.config.*`), so that gate did not run.

## Not tested
No automated test framework exists; ESLint config is missing repo-wide so lint
did not run. Verified via `tsc -b --force`, `npm run build`, `npm run build:demo`
(demo bundle reports `3.0.0-beta.5`), and `bump-version.py --check`. The tour and Help
were NOT walked through in a live browser against a running backend — the new suspend
step, Pavlovian copy, and remote-session save wording were verified by code inspection only.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
