### PR TITLE
Complete and ship the Labrynth terminal CLI to feature parity with the GUI

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -104,10 +104,10 @@ jobs:
           python -c "import reacher; print('reacher OK')"
 
       - name: Install Python build tools
-        run: python -m pip install pyinstaller
+        run: python -m pip install pyinstaller prompt_toolkit httpx websockets
 
       - name: Build application
-        run: python build.py --avrdude "${{ steps.avrdude.outputs.path }}"
+        run: python build.py --cli --avrdude "${{ steps.avrdude.outputs.path }}"
 
       - name: Install Inno Setup
         run: choco install innosetup -y
@@ -122,6 +122,18 @@ jobs:
         with:
           name: windows-installer
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-windows-x64.exe
+
+      - name: Package CLI bundle
+        shell: bash
+        env:
+          VERSION: ${{ needs.version-check.outputs.version }}
+        run: tar -czf "dist/labrynth-cli-${VERSION}-windows-x64.tar.gz" -C dist LabrynthCLI
+
+      - name: Upload CLI bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-cli
+          path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-windows-x64.tar.gz
 
   # -------------------------------------------------------------------
   # macOS — DMG disk image (.dmg) — Apple Silicon (arm64)
@@ -163,10 +175,10 @@ jobs:
           python -c "import reacher; print('reacher OK')"
 
       - name: Install Python build tools
-        run: python -m pip install pyinstaller Pillow
+        run: python -m pip install pyinstaller Pillow prompt_toolkit httpx websockets
 
       - name: Build application
-        run: python build.py --avrdude "${{ steps.avrdude.outputs.path }}"
+        run: python build.py --cli --avrdude "${{ steps.avrdude.outputs.path }}"
 
       - name: Create DMG
         env:
@@ -183,6 +195,17 @@ jobs:
         with:
           name: macos-arm64-dmg
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-macos-arm64.dmg
+
+      - name: Package CLI bundle
+        env:
+          VERSION: ${{ needs.version-check.outputs.version }}
+        run: tar -czf "dist/labrynth-cli-${VERSION}-macos-arm64.tar.gz" -C dist LabrynthCLI
+
+      - name: Upload CLI bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64-cli
+          path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-macos-arm64.tar.gz
 
   # -------------------------------------------------------------------
   # Linux — DEB package (.deb), tarball (.tar.gz), AppImage
@@ -224,10 +247,10 @@ jobs:
           python -c "import reacher; print('reacher OK')"
 
       - name: Install Python build tools
-        run: python -m pip install pyinstaller
+        run: python -m pip install pyinstaller prompt_toolkit httpx websockets
 
       - name: Build application
-        run: python build.py --avrdude "${{ steps.avrdude.outputs.path }}"
+        run: python build.py --cli --avrdude "${{ steps.avrdude.outputs.path }}"
 
       - name: Build DEB package
         env:
@@ -259,6 +282,11 @@ jobs:
         env:
           VERSION: ${{ needs.version-check.outputs.version }}
         run: tar -czf "labrynth-${VERSION}-linux-x64.tar.gz" -C dist Labrynth
+
+      - name: Build CLI tarball
+        env:
+          VERSION: ${{ needs.version-check.outputs.version }}
+        run: tar -czf "labrynth-cli-${VERSION}-linux-x64.tar.gz" -C dist LabrynthCLI
 
       - name: Build AppImage
         env:
@@ -320,6 +348,7 @@ jobs:
           path: |
             labrynth_${{ needs.version-check.outputs.version }}_amd64.deb
             labrynth-${{ needs.version-check.outputs.version }}-linux-x64.tar.gz
+            labrynth-cli-${{ needs.version-check.outputs.version }}-linux-x64.tar.gz
             labrynth-${{ needs.version-check.outputs.version }}-linux-x64.AppImage
 
   # -------------------------------------------------------------------
@@ -354,6 +383,7 @@ jobs:
             | Linux (Debian/Ubuntu) | `labrynth_*_amd64.deb` | `sudo dpkg -i *.deb` |
             | Linux (portable) | `labrynth-*-linux-x64.AppImage` | Any distro |
             | Linux (tarball) | `labrynth-*-linux-x64.tar.gz` | Extract and run |
+            | Terminal CLI (all platforms) | `labrynth-cli-*-<os>.tar.gz` | Headless TUI — extract and run `LabrynthCLI` |
 
             <details>
             <summary>Platform-specific notes</summary>

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -136,10 +136,10 @@ jobs:
           python -c "import reacher; print('reacher OK:', reacher.__version__)"
 
       - name: Install Python build tools
-        run: python -m pip install pyinstaller
+        run: python -m pip install pyinstaller prompt_toolkit httpx websockets
 
       - name: Build application
-        run: python build.py --avrdude "${{ steps.avrdude.outputs.path }}"
+        run: python build.py --cli --avrdude "${{ steps.avrdude.outputs.path }}"
 
       - name: Install Inno Setup
         run: choco install innosetup -y
@@ -154,6 +154,18 @@ jobs:
         with:
           name: windows-installer
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-windows-x64.exe
+
+      - name: Package CLI bundle
+        shell: bash
+        env:
+          VERSION: ${{ needs.version-check.outputs.version }}
+        run: tar -czf "dist/labrynth-cli-${VERSION}-windows-x64.tar.gz" -C dist LabrynthCLI
+
+      - name: Upload CLI bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-cli
+          path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-windows-x64.tar.gz
 
   # -------------------------------------------------------------------
   # macOS — DMG disk image (.dmg) — Apple Silicon (arm64)
@@ -197,10 +209,10 @@ jobs:
           python -c "import reacher; print('reacher OK:', reacher.__version__)"
 
       - name: Install Python build tools
-        run: python -m pip install pyinstaller Pillow
+        run: python -m pip install pyinstaller Pillow prompt_toolkit httpx websockets
 
       - name: Build application
-        run: python build.py --avrdude "${{ steps.avrdude.outputs.path }}"
+        run: python build.py --cli --avrdude "${{ steps.avrdude.outputs.path }}"
 
       - name: Create DMG
         env:
@@ -217,6 +229,17 @@ jobs:
         with:
           name: macos-arm64-dmg
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-macos-arm64.dmg
+
+      - name: Package CLI bundle
+        env:
+          VERSION: ${{ needs.version-check.outputs.version }}
+        run: tar -czf "dist/labrynth-cli-${VERSION}-macos-arm64.tar.gz" -C dist LabrynthCLI
+
+      - name: Upload CLI bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64-cli
+          path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-macos-arm64.tar.gz
 
   # -------------------------------------------------------------------
   # Linux — DEB package (.deb), tarball (.tar.gz), AppImage
@@ -260,10 +283,10 @@ jobs:
           python -c "import reacher; print('reacher OK:', reacher.__version__)"
 
       - name: Install Python build tools
-        run: python -m pip install pyinstaller
+        run: python -m pip install pyinstaller prompt_toolkit httpx websockets
 
       - name: Build application
-        run: python build.py --avrdude "${{ steps.avrdude.outputs.path }}"
+        run: python build.py --cli --avrdude "${{ steps.avrdude.outputs.path }}"
 
       - name: Build DEB package
         env:
@@ -295,6 +318,11 @@ jobs:
         env:
           VERSION: ${{ needs.version-check.outputs.version }}
         run: tar -czf "labrynth-${VERSION}-linux-x64.tar.gz" -C dist Labrynth
+
+      - name: Build CLI tarball
+        env:
+          VERSION: ${{ needs.version-check.outputs.version }}
+        run: tar -czf "labrynth-cli-${VERSION}-linux-x64.tar.gz" -C dist LabrynthCLI
 
       - name: Build AppImage
         env:
@@ -356,6 +384,7 @@ jobs:
           path: |
             labrynth_${{ needs.version-check.outputs.version }}_amd64.deb
             labrynth-${{ needs.version-check.outputs.version }}-linux-x64.tar.gz
+            labrynth-cli-${{ needs.version-check.outputs.version }}-linux-x64.tar.gz
             labrynth-${{ needs.version-check.outputs.version }}-linux-x64.AppImage
 
   # -------------------------------------------------------------------
@@ -400,6 +429,7 @@ jobs:
             | Linux (Debian/Ubuntu) | `labrynth_*_amd64.deb` | `sudo dpkg -i *.deb` |
             | Linux (portable) | `labrynth-*-linux-x64.AppImage` | Any distro |
             | Linux (tarball) | `labrynth-*-linux-x64.tar.gz` | Extract and run |
+            | Terminal CLI (all platforms) | `labrynth-cli-*-<os>.tar.gz` | Headless TUI — extract and run `LabrynthCLI` |
 
             > Not all platforms may be available for this build — check the attached assets.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,17 @@ reacher-cli                  # Console-script alias (same as `python -m cli`)
 
 ```bash
 pip install -e ../reacher                 # First-time/dev: install reacher (ships firmware hex)
-python build.py                           # All 4 stages
+python build.py                           # All 4 stages (GUI bundle: Labrynth)
 python build.py --skip-frontend           # Reuse existing web/dist/
 python build.py --avrdude /usr/bin/avrdude  # Bundle a specific avrdude binary
+python build.py --cli                     # GUI + standalone LabrynthCLI console bundle
+python build.py --cli-only                # Only LabrynthCLI (skips frontend; ships no static/)
 ```
+
+Building the CLI bundle needs the `[cli]` extras importable (`pip install -e ".[cli]"`).
+The CLI bundle (`labrynth-cli.spec` → `dist/LabrynthCLI/`) is a `console=True` one-dir
+build for headless hosts; it omits the React frontend and, when frozen, re-spawns itself
+as the reacher backend via the `REACHER_RUN_BACKEND` trampoline in `cli/__main__.py`.
 
 Build pipeline: (0) validate env (reacher install + its bundled firmware hex) → (1) `npm ci && npm run build` → (2) verify assets → (3) PyInstaller. Firmware hex is sourced from the installed `reacher` package (`reacher/hex/<board>/`) — no compile or fetch step. **Output: `dist/Labrynth/` (Linux/Windows) or `dist/Labrynth.app` (macOS).**
 
@@ -124,6 +131,7 @@ The CLI mirrors browser-UI capabilities (sessions, hardware, program presets, li
 - **`build.py`** — 4-stage orchestrator. Firmware hex is sourced from the installed `reacher` package via `resolve_reacher_hex_dir()` (uses `importlib.resources`); there is no firmware compile/fetch step. `labrynth.spec` imports the same resolver so both agree on the hex source.
 - **`launcher.py`** — PyInstaller entry point; sets `REACHER_STATIC_DIR` so the bundled backend serves `web/dist/`.
 - **`labrynth.spec`** — bundles `web/dist/` → `static/`, the reacher package's `hex/` → `hex/` (resolved via `build.resolve_reacher_hex_dir()`), and avrdude (binary, companion DLLs/`.so`/`.dylib`, and `avrdude.conf`) → `avrdude/` inside `_MEIPASS`. Avrdude path comes from `REACHER_AVRDUDE_PATH` env var (set by `build.py --avrdude`).
+- **`labrynth-cli.spec`** — the standalone `LabrynthCLI` bundle (entry `cli/__main__.py`, `console=True`, one-dir on every platform). Bundles `hex/` + `avrdude/` but **not** `static/`. Built via `build.py --cli` / `--cli-only`; CI ships it as `labrynth-cli-*-<os>.tar.gz`. The frozen CLI re-spawns itself as the backend (`REACHER_RUN_BACKEND=1`) since `sys.executable` is the frozen binary, not a Python with `-m reacher`.
 
 ### CI/CD (`.github/workflows/`)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ reacher-cli
 
 The CLI auto-detects whether the backend is running. If not, it starts the backend as a subprocess and waits up to 15 seconds for it to become ready.
 
+### Standalone binary (no Python required)
+
+A self-contained `LabrynthCLI` bundle ships with each release (`labrynth-cli-*-<os>.tar.gz`) for headless hosts (e.g. a display-less Raspberry Pi). Extract and run the `LabrynthCLI` executable — it bundles the reacher backend and firmware hex, and starts the backend itself (no separate install). Build it locally with `python build.py --cli` (adds the CLI bundle to the GUI build) or `python build.py --cli-only`.
+
 ### Modes
 
 The CLI operates in four modes:
@@ -141,9 +145,9 @@ Main Menu
 │   │   ├── SA Low
 │   │   ├── SA Extinction
 │   │   └── Back
-│   ├── Paradigm Settings           # Ratio, Step, VI/OM interval, Trace interval
+│   ├── Paradigm Settings           # paradigm-aware: FR/PR Ratio, PR Step, VI/OM interval, Trace
 │   ├── Pavlovian Settings          # (only when paradigm = pavlovian)
-│   │   └── CS+/CS- counts, frequencies, reward probs, cue duration, trace, ITI
+│   │   └── CS+/CS- counts, freqs, reward probs, cue duration, trace, ITI (validated), pulse on/off
 │   ├── Limits                      # Limit type, time, infusion, delay
 │   ├── Start / Stop / Pause        # (context-dependent)
 │   └── Back

--- a/build.py
+++ b/build.py
@@ -15,12 +15,15 @@ straight from the installed reacher package, so the version is pinned by the
 ``reacher`` dependency in pyproject.toml.
 
 Usage:
-  python build.py                          # full build
+  python build.py                          # full GUI build
   python build.py --skip-frontend          # skip npm build
   python build.py --avrdude /usr/bin/avrdude  # explicit avrdude path
+  python build.py --cli                    # build GUI + LabrynthCLI console app
+  python build.py --cli-only               # build only LabrynthCLI (no frontend)
 
 Requires: Python 3.10+, Node.js, npm, PyInstaller (pip install pyinstaller),
 and the reacher package installed (pip install reacher or -e ../reacher).
+Building the CLI also requires the ``[cli]`` extras: pip install -e ".[cli]".
 """
 
 import argparse
@@ -41,6 +44,7 @@ PROJECT_ROOT = SCRIPT_DIR
 FRONTEND_DIR = os.path.join(PROJECT_ROOT, "web")
 FRONTEND_DIST = os.path.join(FRONTEND_DIR, "dist")
 SPEC_FILE = os.path.join(SCRIPT_DIR, "labrynth.spec")
+SPEC_FILE_CLI = os.path.join(SCRIPT_DIR, "labrynth-cli.spec")
 
 PARADIGMS = ("fr", "pr", "vi", "omission", "pavlovian")
 BOARDS = ("uno", "mega")
@@ -98,6 +102,22 @@ def validate_environment():
     else:
         print("ERROR: reacher package ships no firmware hex (reacher/hex/).")
         print("       Reinstall reacher: pip install -e ../reacher")
+        sys.exit(1)
+
+
+def validate_cli_deps():
+    """Verify the [cli] extras are importable so PyInstaller can bundle them."""
+    print("\n=== Stage 0b: Validate CLI dependencies ===")
+    missing = []
+    for mod in ("prompt_toolkit", "httpx", "websockets"):
+        try:
+            __import__(mod)
+            print(f"  [OK] {mod}")
+        except ImportError:
+            missing.append(mod)
+    if missing:
+        print(f"ERROR: CLI dependencies not importable: {', '.join(missing)}")
+        print('       Run: pip install -e ".[cli]"')
         sys.exit(1)
 
 
@@ -178,18 +198,19 @@ def _ensure_real_avrdude(avrdude_path):
     return avrdude_path
 
 
-def validate_assets(avrdude_path):
+def validate_assets(avrdude_path, require_frontend=True):
     """Validate that all required assets exist before packaging."""
     print("\n=== Stage 2: Validate assets ===")
     ok = True
 
-    # Frontend dist
-    index_html = os.path.join(FRONTEND_DIST, "index.html")
-    if os.path.isfile(index_html):
-        print(f"  [OK] Frontend dist: {FRONTEND_DIST}")
-    else:
-        print(f"  [MISSING] Frontend dist: {index_html}")
-        ok = False
+    # Frontend dist (not needed for the CLI-only build, which ships no static/)
+    if require_frontend:
+        index_html = os.path.join(FRONTEND_DIST, "index.html")
+        if os.path.isfile(index_html):
+            print(f"  [OK] Frontend dist: {FRONTEND_DIST}")
+        else:
+            print(f"  [MISSING] Frontend dist: {index_html}")
+            ok = False
 
     # Hex files come from the installed reacher package (board-aware layout).
     hex_dir = resolve_reacher_hex_dir()
@@ -230,9 +251,9 @@ def validate_assets(avrdude_path):
     return avrdude_path
 
 
-def run_pyinstaller(avrdude_path):
-    """Run PyInstaller with the spec file."""
-    print("\n=== Stage 3: Run PyInstaller ===")
+def run_pyinstaller(avrdude_path, spec_file=SPEC_FILE):
+    """Run PyInstaller with the given spec file."""
+    print(f"\n=== Stage 3: Run PyInstaller ({os.path.basename(spec_file)}) ===")
     if not shutil.which("pyinstaller"):
         print("ERROR: pyinstaller not found. Install with: pip install pyinstaller")
         sys.exit(1)
@@ -242,31 +263,31 @@ def run_pyinstaller(avrdude_path):
         env["REACHER_AVRDUDE_PATH"] = avrdude_path
 
     _run(
-        ["pyinstaller", "--noconfirm", "--clean", SPEC_FILE],
+        ["pyinstaller", "--noconfirm", "--clean", spec_file],
         cwd=PROJECT_ROOT,
         env=env,
     )
 
 
-def report_output():
-    """Report the location of the built artifact."""
-    print("\n=== Stage 4: Build complete ===")
+def report_output(name="Labrynth"):
+    """Report the location of a built artifact (GUI ``Labrynth`` or ``LabrynthCLI``)."""
+    print(f"\n=== Stage 4: Build complete ({name}) ===")
     system = platform.system()
 
     if system == "Darwin":
-        app_path = os.path.join(SCRIPT_DIR, "dist", "Labrynth.app")
+        app_path = os.path.join(SCRIPT_DIR, "dist", f"{name}.app")
         if os.path.isdir(app_path):
             print(f"  Output: {app_path}")
             print(f"  Run:    open {app_path}")
             return
     elif system == "Windows":
-        exe_path = os.path.join(SCRIPT_DIR, "dist", "Labrynth", "Labrynth.exe")
+        exe_path = os.path.join(SCRIPT_DIR, "dist", name, f"{name}.exe")
         if os.path.isfile(exe_path):
             print(f"  Output: {os.path.dirname(exe_path)}")
             print(f"  Run:    {exe_path}")
             return
     else:
-        exe_path = os.path.join(SCRIPT_DIR, "dist", "Labrynth", "Labrynth")
+        exe_path = os.path.join(SCRIPT_DIR, "dist", name, name)
         if os.path.isfile(exe_path):
             print(f"  Output: {os.path.dirname(exe_path)}")
             print(f"  Run:    {exe_path}")
@@ -299,6 +320,16 @@ def main():
         default="",
         help="Explicit path to avrdude binary to bundle",
     )
+    parser.add_argument(
+        "--cli",
+        action="store_true",
+        help="Also build the standalone LabrynthCLI console app",
+    )
+    parser.add_argument(
+        "--cli-only",
+        action="store_true",
+        help="Build only LabrynthCLI (no frontend, no GUI bundle)",
+    )
     args = parser.parse_args()
 
     print("Labrynth Build Orchestrator")
@@ -308,6 +339,15 @@ def main():
 
     # Stage 0: Validate (reacher package + its bundled firmware hex)
     validate_environment()
+    if args.cli or args.cli_only:
+        validate_cli_deps()
+
+    # CLI-only: skip frontend entirely; the CLI bundle ships no static/.
+    if args.cli_only:
+        avrdude_path = validate_assets(args.avrdude, require_frontend=False)
+        run_pyinstaller(avrdude_path, SPEC_FILE_CLI)
+        report_output("LabrynthCLI")
+        return
 
     # Stage 1: Frontend
     if args.skip_frontend:
@@ -318,11 +358,16 @@ def main():
     # Stage 2: Validate
     avrdude_path = validate_assets(args.avrdude)
 
-    # Stage 3: PyInstaller
+    # Stage 3: PyInstaller (GUI)
     run_pyinstaller(avrdude_path)
 
-    # Stage 4: Report
+    # Stage 4: Report (GUI)
     report_output()
+
+    # Optional: also build the standalone CLI bundle
+    if args.cli:
+        run_pyinstaller(avrdude_path, SPEC_FILE_CLI)
+        report_output("LabrynthCLI")
 
 
 if __name__ == "__main__":

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -11,10 +11,23 @@ from __future__ import annotations
 import argparse
 import asyncio
 import atexit
+import os
 import socket
 import subprocess
 import sys
 import time
+
+
+def _run_backend() -> None:
+    """Run the reacher backend in-process.
+
+    Used only by the frozen ``LabrynthCLI`` bundle, which re-launches itself
+    with ``REACHER_RUN_BACKEND=1`` as the backend process (``sys.executable``
+    is the frozen binary, so ``-m reacher`` is unavailable there).
+    """
+    from reacher.api.app import main as backend_main
+
+    backend_main()
 
 
 def _is_running(port: int) -> bool:
@@ -33,6 +46,12 @@ def _wait_for_server(port: int, timeout: float = 15.0) -> bool:
 
 
 def main() -> None:
+    # Frozen-bundle backend trampoline: when the CLI re-spawns itself as the
+    # server (see below), run the backend immediately and skip the TUI.
+    if os.environ.get("REACHER_RUN_BACKEND") == "1":
+        _run_backend()
+        return
+
     parser = argparse.ArgumentParser(description="REACHER Terminal CLI")
     parser.add_argument(
         "--port",
@@ -51,12 +70,19 @@ def main() -> None:
 
     if not args.no_server and not _is_running(args.port):
         print(f"Starting REACHER backend on port {args.port}...")
-        import os
 
         env = os.environ.copy()
         env["REACHER_PORT"] = str(args.port)
+        if getattr(sys, "frozen", False):
+            # Frozen bundle: sys.executable is the LabrynthCLI binary, which has
+            # no `-m reacher` entry. Re-launch ourselves as the backend instead
+            # (the REACHER_RUN_BACKEND trampoline at the top of main()).
+            env["REACHER_RUN_BACKEND"] = "1"
+            cmd = [sys.executable]
+        else:
+            cmd = [sys.executable, "-m", "reacher"]
         server_proc = subprocess.Popen(
-            [sys.executable, "-m", "reacher"],
+            cmd,
             env=env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/cli/app.py
+++ b/cli/app.py
@@ -156,7 +156,18 @@ PAVLOVIAN_PARAMS: list[dict] = [
     {"code": 216, "label": "ITI Mean (ms)", "default": "30000"},
     {"code": 217, "label": "ITI Min (ms)", "default": "10000"},
     {"code": 218, "label": "ITI Max (ms)", "default": "90000"},
+    # Pulse configuration (mirrors PULSE_PARAMS in PavlovianSettings.tsx).
+    # Set pulse ON to 0 for a continuous tone.
+    {"code": 374, "label": "CS+ Pulse On (ms)", "default": "0"},
+    {"code": 375, "label": "CS+ Pulse Off (ms)", "default": "0"},
+    {"code": 384, "label": "CS- Pulse On (ms)", "default": "200"},
+    {"code": 385, "label": "CS- Pulse Off (ms)", "default": "200"},
 ]
+
+# ITI parameter codes and the validity rule they must satisfy
+# (mirrors `itiValid` in PavlovianSettings.tsx).
+ITI_CODES = (216, 217, 218)
+ITI_DEFAULTS = {216: 30000, 217: 10000, 218: 90000}
 
 PRESET_COMMAND_MAP: dict[str, dict] = {
     "rh-lever": {"arm": 1001, "disarm": 1000, "params": {"timeout": 1074, "ratio": 1075}},
@@ -280,6 +291,7 @@ class SessionState:
     paradigm_settings: dict = field(
         default_factory=lambda: {"ratio": 1, "step": 1, "interval": 30000, "trace_interval": 0}
     )
+    pavlovian_params: dict = field(default_factory=dict)  # {code: value}, last-set Pavlovian params
     limit_settings: dict = field(
         default_factory=lambda: {"type": "Time", "time_limit": 3600, "infusion_limit": 30, "delay": 60}
     )
@@ -652,36 +664,62 @@ class ReacherCLI:
         return MenuState(title="Program > Apply Preset", items=items)
 
     def _paradigm_settings_menu(self) -> MenuState:
-        items = [
-            MenuItem("Set Ratio", action=lambda: self._prompt_int_input(
+        # Mirror web/src/components/program/ParadigmSettings.tsx: show only the
+        # fields relevant to the active paradigm, with live value suffixes.
+        s = self.session
+        paradigm = s.paradigm if s else None
+        ps = s.paradigm_settings if s else {}
+        show_trace = paradigm in ("fr", "pr", "vi")
+
+        items: list[MenuItem] = []
+        if paradigm in ("fr", "pr"):
+            items.append(MenuItem("Set Ratio", action=lambda: self._prompt_int_input(
                 "Enter ratio:", lambda v: self._send_paradigm_setting("ratio", v)
-            )),
-            MenuItem("Set Step", action=lambda: self._prompt_int_input(
-                "Enter step:", lambda v: self._send_paradigm_setting("step", v)
-            )),
-            MenuItem("Set VI Interval (ms)", action=lambda: self._prompt_int_input(
+            ), suffix=f"({ps.get('ratio', 1)})"))
+        if paradigm == "pr":
+            items.append(MenuItem("Set PR Step", action=lambda: self._prompt_int_input(
+                "Enter PR step:", lambda v: self._send_paradigm_setting("step", v)
+            ), suffix=f"({ps.get('step', 1)})"))
+        if paradigm == "vi":
+            items.append(MenuItem("Set VI Interval (ms)", action=lambda: self._prompt_int_input(
                 "Enter VI interval (ms):", lambda v: self._send_paradigm_setting("vi_interval", v)
-            )),
-            MenuItem("Set OM Interval (ms)", action=lambda: self._prompt_int_input(
-                "Enter OM interval (ms):", lambda v: self._send_paradigm_setting("om_interval", v)
-            )),
-            MenuItem("Set Trace Interval (ms)", action=lambda: self._prompt_int_input(
+            ), suffix=f"({ps.get('interval', 30000)})"))
+        if paradigm == "omission":
+            items.append(MenuItem("Set Omission Interval (ms)", action=lambda: self._prompt_int_input(
+                "Enter omission interval (ms):", lambda v: self._send_paradigm_setting("om_interval", v)
+            ), suffix=f"({ps.get('interval', 30000)})"))
+        if show_trace:
+            items.append(MenuItem("Set Trace Interval (ms)", action=lambda: self._prompt_int_input(
                 "Enter trace interval (ms):", lambda v: self._send_paradigm_setting("trace_interval", v)
-            )),
-            MenuItem("Back", action=self._pop_menu),
-        ]
+            ), suffix=f"({ps.get('trace_interval', 0)})"))
+
+        if not items:
+            hint = "Pavlovian: use Pavlovian Settings" if paradigm == "pavlovian" else "No paradigm selected"
+            items.append(MenuItem(f"──── {hint} ────", is_separator=True))
+
+        items.append(MenuItem("Back", action=self._pop_menu))
         return MenuState(title="Program > Paradigm Settings", items=items)
 
     def _pavlovian_menu(self) -> MenuState:
+        s = self.session
+        tracked = s.pavlovian_params if s else {}
         items = []
         for pp in PAVLOVIAN_PARAMS:
-            items.append(MenuItem(
-                f"Set {pp['label']}",
-                action=lambda code=pp["code"], lbl=pp["label"]: self._prompt_int_input(
-                    f"Enter {lbl}:", lambda v, c=code: self._send_hw_command(c, v)
-                ),
-                suffix=f"({pp['default']})",
-            ))
+            code = pp["code"]
+            label = pp["label"]
+            # ITI fields are cross-validated (min <= mean <= max); everything
+            # else is sent directly.  Both paths record the value so the suffix
+            # reflects the last value set this session.
+            if code in ITI_CODES:
+                action = lambda lbl=label, c=code: self._prompt_int_input(
+                    f"Enter {lbl}:", lambda v, cc=c: self._send_pavlovian_iti(cc, v)
+                )
+            else:
+                action = lambda lbl=label, c=code: self._prompt_int_input(
+                    f"Enter {lbl}:", lambda v, cc=c: self._set_pavlovian_param(cc, v)
+                )
+            cur = tracked.get(code, pp["default"])
+            items.append(MenuItem(f"Set {label}", action=action, suffix=f"({cur})"))
         items.append(MenuItem("Back", action=self._pop_menu))
         return MenuState(title="Program > Pavlovian Settings", items=items)
 
@@ -1115,7 +1153,43 @@ class ReacherCLI:
             self._set_status(f"Unknown setting: {key}", error=True)
             return
         await self._send_hw_command(code, value)
-        self.session.paradigm_settings[key] = value
+        # VI and OM share the single "interval" storage slot (mirrors the GUI,
+        # which keeps one `interval` field but sends 204 for VI / 203 for OM).
+        store_key = "interval" if key in ("vi_interval", "om_interval") else key
+        self.session.paradigm_settings[store_key] = value
+
+    async def _set_pavlovian_param(self, code: int, value: int) -> None:
+        """Send a (non-ITI) Pavlovian parameter and record it for display."""
+        if not self.session:
+            self._set_status("No session", error=True)
+            return
+        await self._send_hw_command(code, value)
+        self.session.pavlovian_params[code] = value
+        self._rebuild_current_menu()
+
+    async def _send_pavlovian_iti(self, code: int, value: int) -> None:
+        """Send an ITI parameter (216/217/218) only if Min <= Mean <= Max.
+
+        Mirrors `itiValid` in PavlovianSettings.tsx: the candidate value is
+        checked against the other two tracked values (falling back to defaults).
+        """
+        if not self.session:
+            self._set_status("No session", error=True)
+            return
+        pp = self.session.pavlovian_params
+        cur = {c: pp.get(c, ITI_DEFAULTS[c]) for c in ITI_CODES}
+        cur[code] = value
+        mean, iti_min, iti_max = cur[216], cur[217], cur[218]
+        if not (iti_min <= mean <= iti_max and iti_min >= 0 and iti_max > 0):
+            self._set_status(
+                f"Invalid ITI: need Min <= Mean <= Max "
+                f"(Min={iti_min}, Mean={mean}, Max={iti_max})",
+                error=True,
+            )
+            return
+        await self._send_hw_command(code, value)
+        self.session.pavlovian_params[code] = value
+        self._rebuild_current_menu()
 
     async def _start_program(self) -> None:
         if not self.session:
@@ -1364,19 +1438,28 @@ class ReacherCLI:
                 f"[{ts}]  {device:<16} {event}"
             ))
 
-            # Update counts
+            # Update counts. The backend emits UPPERCASE device/event strings
+            # (see reacher kernel `_emit("event", ...)`); match them the same way
+            # pushEvent does in web/src/store/useSessionStore.ts. (.upper() keeps
+            # this robust to casing.)
             if self.session:
                 self.session.backend_event_count += 1
-                if event == "infusion":
+                dev = device.upper()
+                evt = event.upper()
+                if dev in ("PUMP", "PUMP_1") and evt == "INFUSION":
                     self.session.infusion_count += 1
-                elif event in ("active_press", "timeout_press", "inactive_press"):
+                elif dev in ("RH_LEVER", "LEVER_RH", "LH_LEVER", "LEVER_LH") and "PRESS" in evt:
                     self.session.press_count += 1
-                    lever = "rh" if "rh" in device.lower() or "right" in device.lower() else "lh"
-                    kind = event.replace("_press", "")
-                    if lever == "rh":
-                        self.session.rh_counts[kind] = self.session.rh_counts.get(kind, 0) + 1
-                    else:
-                        self.session.lh_counts[kind] = self.session.lh_counts.get(kind, 0) + 1
+                    counts = (self.session.rh_counts if dev in ("RH_LEVER", "LEVER_RH")
+                              else self.session.lh_counts)
+                    if evt == "ACTIVE_PRESS":
+                        counts["active"] = counts.get("active", 0) + 1
+                    elif evt == "TIMEOUT_PRESS":
+                        counts["timeout"] = counts.get("timeout", 0) + 1
+                    elif evt == "INACTIVE_PRESS":
+                        counts["inactive"] = counts.get("inactive", 0) + 1
+                elif dev == "PAVLOV" and evt == "TRIAL_START":
+                    self.session.trial_count += 1
 
         elif msg_type == "session_state":
             state = data.get("state", "")
@@ -1409,6 +1492,7 @@ class ReacherCLI:
                 self.session.pause_start = None
                 self.session.infusion_count = 0
                 self.session.press_count = 0
+                self.session.trial_count = 0
                 self.session.backend_event_count = 0
                 self.session.rh_counts = {}
                 self.session.lh_counts = {}
@@ -1464,9 +1548,17 @@ class ReacherCLI:
             self._set_status("No session", error=True)
             return
         try:
+            # Mirror triggerAutoExport in web/src/hooks/useSessionWebSockets.ts.
+            # Microscope frame rate/averaging are omitted: the CLI has no UI to
+            # configure them, matching the GUI's conditional spread when the
+            # microscope is disarmed.
             export_payload = {
                 "session_name": self.session.name or "",
                 "notes": self.session.file_config.get("notes", ""),
+                "infusion_count": self.session.infusion_count,
+                "press_count": self.session.press_count,
+                "trial_count": self.session.trial_count,
+                "program_start_time": self.session.program_start,
             }
             resp = await self.api.export_zip(self.session.id, **export_payload)
             path = resp.get("path", resp.get("file", "exported"))

--- a/labrynth-cli.spec
+++ b/labrynth-cli.spec
@@ -1,0 +1,160 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for the standalone LabrynthCLI executable.
+
+A console/TUI build for headless REACHER hosts (e.g. a display-less
+Raspberry Pi). Unlike the GUI ``labrynth.spec`` it:
+  - uses ``cli/__main__.py`` as the entry point,
+  - builds a console app (prompt_toolkit needs a TTY),
+  - does NOT bundle the React frontend (no ``static/``).
+
+The frozen CLI re-launches itself as the backend via the
+``REACHER_RUN_BACKEND`` trampoline in ``cli/__main__.py``.
+
+Bundles:
+  - Python backend (FastAPI + kernel + all deps)
+  - Pre-compiled firmware  → _MEIPASS/hex/   (for firmware upload)
+  - Platform avrdude       → _MEIPASS/avrdude/
+
+Build:
+  pyinstaller labrynth-cli.spec
+"""
+
+import os
+import sys
+
+from PyInstaller.utils.hooks import collect_submodules
+
+# ---------------------------------------------------------------------------
+# Paths — all relative to this spec file (which lives at the repo root)
+# ---------------------------------------------------------------------------
+
+SPEC_DIR = os.path.abspath(SPECPATH)
+PROJECT_ROOT = SPEC_DIR
+
+# Firmware hex ships as package data inside the installed reacher dependency.
+# Resolve it via build.py's shared helper so spec and orchestrator agree.
+sys.path.insert(0, SPEC_DIR)
+from build import resolve_reacher_hex_dir  # noqa: E402
+
+HEX_DIR = resolve_reacher_hex_dir()
+
+# avrdude — default platform location; override via build.py --avrdude
+AVRDUDE_PATH = os.environ.get("REACHER_AVRDUDE_PATH", "")
+
+# ---------------------------------------------------------------------------
+# Data files to bundle (no React frontend in the CLI build)
+# ---------------------------------------------------------------------------
+
+datas = []
+
+# Firmware hex files (from the reacher package) → hex/
+if HEX_DIR and os.path.isdir(HEX_DIR):
+    datas.append((HEX_DIR, "hex"))
+else:
+    print(f"WARNING: reacher firmware hex directory not found (resolved: {HEX_DIR})")
+
+# avrdude binary + companion DLLs + conf → avrdude/  (see labrynth.spec for why
+# the executable + libraries go through ``binaries`` rather than ``datas``).
+extra_binaries = []
+
+if AVRDUDE_PATH and os.path.isfile(AVRDUDE_PATH):
+    extra_binaries.append((AVRDUDE_PATH, "avrdude"))
+    _avrdude_dir = os.path.dirname(AVRDUDE_PATH)
+
+    for _f in os.listdir(_avrdude_dir):
+        _fpath = os.path.join(_avrdude_dir, _f)
+        if os.path.isfile(_fpath) and _f.lower().endswith((".dll", ".so", ".dylib")):
+            extra_binaries.append((_fpath, "avrdude"))
+
+    for _conf in [
+        os.path.join(_avrdude_dir, "..", "etc", "avrdude.conf"),
+        os.path.join(_avrdude_dir, "avrdude.conf"),
+    ]:
+        if os.path.isfile(_conf):
+            datas.append((os.path.abspath(_conf), "avrdude"))
+            break
+else:
+    extra_binaries = []
+    print("NOTE: No avrdude binary bundled (set REACHER_AVRDUDE_PATH or use build.py --avrdude)")
+
+# ---------------------------------------------------------------------------
+# Hidden imports — uvicorn/pyserial internals (mirrors labrynth.spec) plus the
+# CLI package and its deps, and the reacher backend entry the CLI re-spawns.
+# ---------------------------------------------------------------------------
+
+hiddenimports = [
+    "uvicorn.logging",
+    "uvicorn.lifespan.on",
+    "uvicorn.protocols.http.auto",
+    "uvicorn.protocols.http.h11_impl",
+    "uvicorn.protocols.http.httptools_impl",
+    "uvicorn.protocols.websockets.auto",
+    "uvicorn.protocols.websockets.wsproto_impl",
+    "uvicorn.protocols.websockets.websockets_impl",
+    "uvicorn.loops.auto",
+    "uvicorn.loops.asyncio",
+    "serial.tools.list_ports",
+    "serial.tools.list_ports_common",
+    "serial.tools.list_ports_windows",
+    "serial.tools.list_ports_posix",
+    "serial.tools.list_ports_linux",
+    "serial.tools.list_ports_osx",
+    # CLI package + its runtime dependencies
+    "cli",
+    "cli.app",
+    "cli.client",
+    "httpx",
+    "websockets",
+    # Backend entry the frozen CLI re-spawns as the server process
+    "reacher.api.app",
+]
+# prompt_toolkit pulls in submodules dynamically; collect them all.
+hiddenimports += collect_submodules("prompt_toolkit")
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+a = Analysis(
+    [os.path.join(SPEC_DIR, "cli", "__main__.py")],
+    pathex=[],
+    binaries=extra_binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="LabrynthCLI",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,  # prompt_toolkit TUI needs a console/TTY
+    icon=os.path.join(PROJECT_ROOT, "installer", "icons", "labrynth-icon.ico"),
+)
+
+# ---------------------------------------------------------------------------
+# Output — a one-dir COLLECT on every platform (a console TUI must be launched
+# from a terminal; a macOS .app BUNDLE launched from Finder has no TTY).
+# ---------------------------------------------------------------------------
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="LabrynthCLI",
+)


### PR DESCRIPTION
## Intent
Researchers running headless REACHER sessions (e.g. a display-less Raspberry Pi) need a terminal UI that does everything the React GUI does. This closes the remaining parity gaps in the CLI's program settings and data export, and ships the CLI as a standalone installable executable.

## Approach the AI took
Settings-parity scope (custom user-preset persistence deliberately out of scope):
- **Paradigm-aware settings** (`cli/app.py` `_paradigm_settings_menu`): shows only the active paradigm's fields with live value suffixes, mirroring `ParadigmSettings.tsx`; VI/OM now store into the shared `interval` slot.
- **Pavlovian ITI + pulse**: added pulse codes 374/375/384/385; `_send_pavlovian_iti` enforces `min<=mean<=max`; new `SessionState.pavlovian_params`.
- **Export payload** (`_export_zip`): ships infusion/press/trial counts + `program_start_time`. Fixed the WS counter matching to the backend's UPPERCASE event strings (counts were stuck at 0) and added `trial_count`.
- **Standalone bundle**: new `labrynth-cli.spec` (console one-dir, no `static/`); frozen-mode `REACHER_RUN_BACKEND` self-respawn trampoline in `cli/__main__.py`; `build.py --cli/--cli-only`; both CI workflows build/package/upload `labrynth-cli-*-<os>.tar.gz`; docs updated.

No reacher backend or firmware change — all command codes are already supported and used by the GUI over the same REST contract.

## Risk
The CLI source changes (Areas 1-3) are logic-verified, but the **bundling path is untested on a real frozen binary**: the frozen-mode backend self-respawn (`REACHER_RUN_BACKEND`) and prompt_toolkit's TTY behavior inside a PyInstaller `console=True` build need a per-platform smoke test before relying on the shipped artifact. The WS counter fix changes event-matching for the live monitor too (now uppercase-based); if any backend path emits lowercase device/event strings, those events won't count (mitigated by `.upper()` normalization).

## Not tested
No end-to-end run against a live backend or Arduino (reacher/prompt_toolkit aren't installed in this environment). The PyInstaller build (`python build.py --cli`) and the resulting `LabrynthCLI` binary were not executed on any platform. CI workflow changes are YAML-validated only, not run. Verification was via stubbed-dependency logic tests of the menu builders, ITI validation, export payload, and WS counters.

Closes #31
