### PR TITLE
task: surface re-enabled Pavlovian commands (counterbalance, consumption, pulse_config) in frontend

### DIFF
--- a/cli/app.py
+++ b/cli/app.py
@@ -144,19 +144,26 @@ PARADIGM_SETTING_CODES = {
     "trace_interval": 220,
 }
 
-PAVLOVIAN_PARAMS: list[dict] = [
-    {"code": 206, "label": "CS+ Reward Prob (%)", "default": "100"},
-    {"code": 207, "label": "CS- Reward Prob (%)", "default": "0"},
-    {"code": 208, "label": "CS+ Count", "default": "50"},
-    {"code": 209, "label": "CS- Count", "default": "50"},
-    {"code": 210, "label": "CS+ Frequency (Hz)", "default": "12000"},
-    {"code": 211, "label": "CS- Frequency (Hz)", "default": "3000"},
-    {"code": 213, "label": "Cue Duration (ms)", "default": "2000"},
-    {"code": 214, "label": "Trace Interval (ms)", "default": "1000"},
-    {"code": 216, "label": "ITI Mean (ms)", "default": "30000"},
-    {"code": 217, "label": "ITI Min (ms)", "default": "10000"},
-    {"code": 218, "label": "ITI Max (ms)", "default": "90000"},
-]
+# Curated short labels for Pavlovian params. The param *list* is sourced
+# dynamically from reacher's registry (see _pavlovian_menu); this map only
+# supplies nicer labels than the registry's verbose `description`. A code missing
+# here falls back to the spec's description, so new registry params still render.
+PAV_LABEL_OVERRIDES: dict[int, str] = {
+    206: "CS+ Reward Prob (%)",
+    207: "CS- Reward Prob (%)",
+    208: "CS+ Count",
+    209: "CS- Count",
+    210: "CS+ Frequency (Hz)",
+    211: "CS- Frequency (Hz)",
+    212: "Counterbalance",
+    213: "Cue Duration (ms)",
+    214: "Trace Interval (ms)",
+    215: "Consumption Window (ms)",
+    216: "ITI Mean (ms)",
+    217: "ITI Min (ms)",
+    218: "ITI Max (ms)",
+    219: "Pulse Config",
+}
 
 PRESET_COMMAND_MAP: dict[str, dict] = {
     "rh-lever": {"arm": 1001, "disarm": 1000, "params": {"timeout": 1074, "ratio": 1075}},
@@ -285,6 +292,8 @@ class SessionState:
     )
     file_config: dict = field(default_factory=lambda: {"filename": "", "destination": "", "notes": ""})
     backend_event_count: int = 0
+    # Pavlovian command specs sourced from reacher's registry (get_commands_for_paradigm)
+    pav_commands: list[dict] = field(default_factory=list)
 
     @property
     def elapsed(self) -> float:
@@ -674,14 +683,33 @@ class ReacherCLI:
 
     def _pavlovian_menu(self) -> MenuState:
         items = []
-        for pp in PAVLOVIAN_PARAMS:
-            items.append(MenuItem(
-                f"Set {pp['label']}",
-                action=lambda code=pp["code"], lbl=pp["label"]: self._prompt_int_input(
-                    f"Enter {lbl}:", lambda v, c=code: self._send_hw_command(c, v)
-                ),
-                suffix=f"({pp['default']})",
-            ))
+        specs = self.session.pav_commands if self.session else []
+        # Settable Pavlovian scalar params (registry already paradigm-filtered).
+        scalar = sorted(
+            (s for s in specs if s.get("payload_key") and 206 <= s.get("code", 0) <= 219),
+            key=lambda s: s["code"],
+        )
+        for sp in scalar:
+            code = sp["code"]
+            label = PAV_LABEL_OVERRIDES.get(code) or sp.get("description") or f"Code {code}"
+            if sp.get("payload_type") == "bool":
+                items.append(MenuItem(
+                    f"Set {label}",
+                    action=lambda c=code, lbl=label: self._prompt_select(
+                        f"{lbl}:",
+                        [("Off", "0"), ("On", "1")],
+                        lambda v, c2=c: self._send_hw_command(c2, int(v)),
+                    ),
+                ))
+            else:
+                items.append(MenuItem(
+                    f"Set {label}",
+                    action=lambda c=code, lbl=label: self._prompt_int_input(
+                        f"Enter {lbl}:", lambda v, c2=c: self._send_hw_command(c2, v)
+                    ),
+                ))
+        if not scalar:
+            items.append(MenuItem("Reload commands", action=self._load_pav_commands))
         items.append(MenuItem("Back", action=self._pop_menu))
         return MenuState(title="Program > Pavlovian Settings", items=items)
 
@@ -890,6 +918,8 @@ class ReacherCLI:
             sid = resp.get("session_id") or resp.get("id", "")
             self.session = SessionState(id=sid, port=port, paradigm=paradigm)
             self._set_status(f"Session created: {sid[:8]}...")
+            if paradigm and paradigm.lower() == "pavlovian":
+                await self._load_pav_commands()
             self._rebuild_current_menu()
         except Exception as exc:
             self._set_status(f"Create session failed: {exc}", error=True)
@@ -969,10 +999,23 @@ class ReacherCLI:
             self._set_status(f"Firmware uploaded: {paradigm} ({board})")
             if not self.session.name:
                 self.session.name = f"{paradigm.upper()} {self.session.port}"
+            if paradigm.lower() == "pavlovian":
+                await self._load_pav_commands()
             self._rebuild_current_menu()
         except Exception as exc:
             self.session.state = "idle"
             self._set_status(f"Upload failed: {exc}", error=True)
+
+    async def _load_pav_commands(self) -> None:
+        """Fetch the registry-driven Pavlovian command set for the session's paradigm."""
+        if not self.session:
+            return
+        try:
+            resp = await self.api.get_commands(self.session.id)
+            self.session.pav_commands = resp.get("commands", [])
+            self._rebuild_current_menu()
+        except Exception as exc:
+            self._set_status(f"Failed to load Pavlovian commands: {exc}", error=True)
 
     async def _reset_session(self) -> None:
         if not self.session:

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -176,11 +176,33 @@ export const sendCommand = async (_id: string, _code: number, _value?: number) =
   status: "ok",
 });
 
+// Minimal Pavlovian command set mirroring reacher's registry, so demo mode can
+// render the dynamically-sourced Pavlovian panel (real backend returns these via
+// get_commands_for_paradigm). Only the settable scalar/pulse params are needed.
+const PAVLOVIAN_MOCK_COMMANDS = [
+  { code: 206, name: "PAV_CS_PLUS_PROB", description: "CS+ probability (0-100)", payload_key: "probability", payload_type: "int" },
+  { code: 207, name: "PAV_CS_MINUS_PROB", description: "CS- probability (0-100)", payload_key: "probability", payload_type: "int" },
+  { code: 208, name: "PAV_CS_PLUS_COUNT", description: "Number of CS+ trials", payload_key: "count", payload_type: "int" },
+  { code: 209, name: "PAV_CS_MINUS_COUNT", description: "Number of CS- trials", payload_key: "count", payload_type: "int" },
+  { code: 212, name: "PAV_COUNTERBALANCE", description: "Enable/disable counterbalancing", payload_key: "enabled", payload_type: "bool" },
+  { code: 214, name: "PAV_TRACE_INTERVAL", description: "Trace interval between CS and US (ms)", payload_key: "interval", payload_type: "int" },
+  { code: 215, name: "PAV_CONSUMPTION", description: "Consumption window duration (ms)", payload_key: "duration", payload_type: "int" },
+  { code: 216, name: "PAV_ITI_MEAN", description: "Mean inter-trial interval (ms)", payload_key: "iti_mean", payload_type: "int" },
+  { code: 217, name: "PAV_ITI_MIN", description: "Minimum inter-trial interval (ms)", payload_key: "iti_min", payload_type: "int" },
+  { code: 218, name: "PAV_ITI_MAX", description: "Maximum inter-trial interval (ms)", payload_key: "iti_max", payload_type: "int" },
+  { code: 219, name: "PAV_PULSE_CONFIG", description: "Pulse configuration for Pavlovian paradigm", payload_key: "config", payload_type: "int" },
+  { code: 374, name: "CUE_SET_PULSE_ON", description: "CS+ pulse on (ms)", payload_key: "pulse_on", payload_type: "int" },
+  { code: 375, name: "CUE_SET_PULSE_OFF", description: "CS+ pulse off (ms)", payload_key: "pulse_off", payload_type: "int" },
+  { code: 384, name: "CUE2_SET_PULSE_ON", description: "CS- pulse on (ms)", payload_key: "pulse_on", payload_type: "int" },
+  { code: 385, name: "CUE2_SET_PULSE_OFF", description: "CS- pulse off (ms)", payload_key: "pulse_off", payload_type: "int" },
+];
+
 export const getCommands = async (id: string) => {
   const session = useSessionStore.getState().sessions.get(id);
+  const paradigm = session?.paradigm ?? "fr";
   return {
-    paradigm: session?.paradigm ?? "fr",
-    commands: [],
+    paradigm,
+    commands: paradigm.toLowerCase() === "pavlovian" ? PAVLOVIAN_MOCK_COMMANDS : [],
   };
 };
 

--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -9,23 +9,9 @@ import { ParadigmFlowDiagram } from "./ParadigmFlowDiagram";
 import { ValidationWarningPanel } from "./ValidationWarningPanel";
 import type { ValidationResult } from "../../api/client";
 
-const PAV_CODE_LABELS: Record<number, string> = {
-  206: "CS+ Reward Prob (%)",
-  207: "CS- Reward Prob (%)",
-  208: "CS+ Count",
-  209: "CS- Count",
-  210: "CS+ Frequency (Hz)",
-  211: "CS- Frequency (Hz)",
-  213: "Cue Duration (ms)",
-  214: "Trace Interval (ms)",
-  216: "ITI Mean (ms)",
-  217: "ITI Min (ms)",
-  218: "ITI Max (ms)",
-  374: "CS+ Pulse On (ms)",
-  375: "CS+ Pulse Off (ms)",
-  384: "CS- Pulse On (ms)",
-  385: "CS- Pulse Off (ms)",
-};
+// Shared with PavlovianSettings so the start-summary labels every param the
+// registry can surface (incl. re-enabled 212/215/219), with no separate drift.
+import { LABEL_OVERRIDES as PAV_CODE_LABELS } from "../program/pavLabels";
 
 const DEVICE_LABELS: Record<string, string> = {
   rhLever: "RH Lever",

--- a/web/src/components/program/PavlovianSettings.tsx
+++ b/web/src/components/program/PavlovianSettings.tsx
@@ -1,84 +1,119 @@
 import { useState, useEffect } from "react";
 import { getClientForSession } from "../../api/sessionClient";
 import { useSessionStore } from "../../store/useSessionStore";
+import type { CommandSpec } from "../../types";
+import { ITI_CODES, PULSE_CODES, labelForCode } from "./pavLabels";
 
 interface Props {
   sessionId: string;
 }
 
-interface PavParam {
-  code: number;
-  label: string;
-  default: number;
-}
-
-const PAV_PARAMS: PavParam[] = [
-  { code: 206, label: "CS+ Reward Prob (%)", default: 100 },
-  { code: 207, label: "CS- Reward Prob (%)", default: 0 },
-  { code: 208, label: "CS+ Count", default: 50 },
-  { code: 209, label: "CS- Count", default: 50 },
-  { code: 214, label: "Trace Interval (ms)", default: 1000 },
-];
-
-const PULSE_PARAMS: PavParam[] = [
-  { code: 374, label: "CS+ Pulse On (ms)", default: 0 },
-  { code: 375, label: "CS+ Pulse Off (ms)", default: 0 },
-  { code: 384, label: "CS- Pulse On (ms)", default: 200 },
-  { code: 385, label: "CS- Pulse Off (ms)", default: 200 },
-];
-
-const ITI_DEFAULTS = {
-  itiMean: 30000,
-  itiMin: 10000,
-  itiMax: 90000,
+/**
+ * Fallback defaults for codes not supplied by an applied preset (or a fresh
+ * session with no preset). The registry decides *which* params render; these
+ * supply sane initial values. Codes absent here default to 0.
+ */
+const CODE_DEFAULTS: Record<number, number> = {
+  206: 100,   // CS+ Reward Prob (%)
+  207: 0,     // CS- Reward Prob (%)
+  208: 50,    // CS+ Count
+  209: 50,    // CS- Count
+  212: 0,     // Counterbalance (off)
+  214: 1000,  // Trace Interval (ms)
+  215: 5000,  // Consumption Window (ms) — must be >= 1 (backend bound)
+  219: 0,     // Pulse Config
+  374: 0,     // CS+ Pulse On (ms) — continuous
+  375: 0,     // CS+ Pulse Off (ms)
+  384: 200,   // CS- Pulse On (ms)
+  385: 200,   // CS- Pulse Off (ms)
 };
+
+const ITI_FALLBACK = { 216: 30000, 217: 10000, 218: 90000 } as const;
+
+const [ITI_MEAN, ITI_MIN, ITI_MAX] = ITI_CODES;
 
 export function PavlovianSettings({ sessionId }: Props) {
   const session = useSessionStore((s) => s.sessions.get(sessionId));
   const setPavlovianParams = useSessionStore((s) => s.setPavlovianParams);
 
-  const [values, setValues] = useState<Record<number, number>>(() => {
-    const stored = session?.pavlovianParams;
-    return Object.fromEntries(
-      [...PAV_PARAMS, ...PULSE_PARAMS].map((p) => [p.code, stored?.[p.code] ?? p.default])
-    );
-  });
-  const [itiMean, setItiMean] = useState(() => session?.pavlovianParams?.[216] ?? ITI_DEFAULTS.itiMean);
-  const [itiMin, setItiMin] = useState(() => session?.pavlovianParams?.[217] ?? ITI_DEFAULTS.itiMin);
-  const [itiMax, setItiMax] = useState(() => session?.pavlovianParams?.[218] ?? ITI_DEFAULTS.itiMax);
+  // Pavlovian param list is sourced from reacher's command registry (already
+  // paradigm-filtered + deprecation-stripped server-side), so re-enabled or
+  // newly added params surface automatically with no frontend code change.
+  const [specs, setSpecs] = useState<CommandSpec[]>([]);
+  const [values, setValues] = useState<Record<number, number>>({});
+  const [itiMean, setItiMean] = useState(() => session?.pavlovianParams?.[ITI_MEAN] ?? ITI_FALLBACK[216]);
+  const [itiMin, setItiMin] = useState(() => session?.pavlovianParams?.[ITI_MIN] ?? ITI_FALLBACK[217]);
+  const [itiMax, setItiMax] = useState(() => session?.pavlovianParams?.[ITI_MAX] ?? ITI_FALLBACK[218]);
 
-  const getItiValues = (): Record<number, number> => {
-    return { 216: itiMean, 217: itiMin, 218: itiMax };
-  };
+  // Fetch the registry-driven command set for this session's paradigm.
+  useEffect(() => {
+    let cancelled = false;
+    getClientForSession(sessionId)
+      ?.getCommands(sessionId)
+      .then((r) => {
+        if (!cancelled) setSpecs(r.commands as unknown as CommandSpec[]);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, session?.paradigm]);
+
+  // Partition the dynamic command set into the three UI groups. Pulse codes live
+  // in the 3xx range, so partition by explicit code sets rather than a range.
+  const isSettable = (s: CommandSpec) => s.payload_key != null;
+  const scalarParams = specs.filter(
+    (s) => isSettable(s) && s.code >= 206 && s.code <= 219 && !ITI_CODES.includes(s.code as (typeof ITI_CODES)[number]),
+  );
+  const pulseParams = specs.filter((s) => PULSE_CODES.includes(s.code as (typeof PULSE_CODES)[number]));
+  const itiPresent = ITI_CODES.every((c) => specs.some((s) => s.code === c));
+
+  // Seed scalar + pulse values once the spec list arrives (or the session
+  // changes). Keyed on (sessionId, specs) so user edits within a session aren't
+  // clobbered. Values prefer stored params, then preset/local default, then 0.
+  useEffect(() => {
+    if (specs.length === 0) return;
+    const stored = session?.pavlovianParams;
+    const next: Record<number, number> = {};
+    for (const p of [...scalarParams, ...pulseParams]) {
+      next[p.code] = stored?.[p.code] ?? CODE_DEFAULTS[p.code] ?? 0;
+    }
+    setValues(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, specs]);
+
+  const getItiValues = (): Record<number, number> => ({ [ITI_MEAN]: itiMean, [ITI_MIN]: itiMin, [ITI_MAX]: itiMax });
 
   const getAllValues = (): Record<number, number> => ({
     ...values,
-    ...getItiValues(),
+    ...(itiPresent ? getItiValues() : {}),
   });
 
-  // Sync to store whenever values change
+  // Sync to store once seeded (guard against clobbering with an empty map before
+  // the spec list has loaded).
   useEffect(() => {
+    if (Object.keys(values).length === 0) return;
     setPavlovianParams(sessionId, getAllValues());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [values, itiMean, itiMin, itiMax, sessionId]);
 
-  const update = (code: number, val: number) =>
-    setValues((prev) => ({ ...prev, [code]: val }));
+  const update = (code: number, val: number) => setValues((prev) => ({ ...prev, [code]: val }));
 
   const send = (code: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code, values[code]);
 
   const itiValid = itiMin <= itiMean && itiMean <= itiMax && itiMin >= 0 && itiMax > 0;
 
   const sendAll = async () => {
-    for (const p of PAV_PARAMS) {
-      await getClientForSession(sessionId)?.sendCommand(sessionId,p.code, values[p.code]);
+    const client = getClientForSession(sessionId);
+    for (const p of [...scalarParams, ...pulseParams]) {
+      await client?.sendCommand(sessionId, p.code, values[p.code]);
     }
-    for (const p of PULSE_PARAMS) {
-      await getClientForSession(sessionId)?.sendCommand(sessionId,p.code, values[p.code]);
+    if (itiPresent) {
+      const iti = getItiValues();
+      await client?.sendCommand(sessionId, ITI_MEAN, iti[ITI_MEAN]);
+      await client?.sendCommand(sessionId, ITI_MIN, iti[ITI_MIN]);
+      await client?.sendCommand(sessionId, ITI_MAX, iti[ITI_MAX]);
     }
-    const iti = getItiValues();
-    await getClientForSession(sessionId)?.sendCommand(sessionId,216, iti[216]);
-    await getClientForSession(sessionId)?.sendCommand(sessionId,217, iti[217]);
-    await getClientForSession(sessionId)?.sendCommand(sessionId,218, iti[218]);
   };
 
   return (
@@ -89,98 +124,111 @@ export function PavlovianSettings({ sessionId }: Props) {
           className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Send All</button>
       </div>
       <div className="grid gap-2 sm:grid-cols-2">
-        {PAV_PARAMS.map((p) => (
+        {scalarParams.map((p) => (
           <div key={p.code} className="flex items-center gap-2">
-            <label className="text-sm flex-1 text-theme-text/60">{p.label}:</label>
-            <input
-              type="number"
-              value={values[p.code]}
-              onChange={(e) => update(p.code, +e.target.value)}
-              className="w-20 input-base"
-            />
+            <label className="text-sm flex-1 text-theme-text/60">{labelForCode(p.code, specs)}:</label>
+            {p.payload_type === "bool" ? (
+              <input
+                type="checkbox"
+                checked={values[p.code] === 1}
+                onChange={(e) => update(p.code, e.target.checked ? 1 : 0)}
+                className="h-4 w-4 accent-accent"
+              />
+            ) : (
+              <input
+                type="number"
+                value={values[p.code] ?? 0}
+                onChange={(e) => update(p.code, +e.target.value)}
+                className="w-20 input-base"
+              />
+            )}
             <button onClick={() => send(p.code)} className="btn-sm bg-accent text-accent-contrast text-xs">Set</button>
           </div>
         ))}
       </div>
 
       {/* Pulse Configuration */}
-      <div className="mt-4 border-t border-theme-border pt-4">
-        <span className="text-sm font-medium text-theme-text">Pulse Configuration</span>
-        <p className="text-xs text-theme-text/40 mt-1">Set pulse ON to 0 for continuous tone. CS+ defaults to continuous; CS- defaults to 200ms/200ms pulsed.</p>
-        <div className="grid gap-2 sm:grid-cols-2 mt-3">
-          {PULSE_PARAMS.map((p) => (
-            <div key={p.code} className="flex items-center gap-2">
-              <label className="text-sm flex-1 text-theme-text/60">{p.label}:</label>
-              <input
-                type="number"
-                value={values[p.code]}
-                min={0} max={60000}
-                onChange={(e) => update(p.code, +e.target.value)}
-                className="w-20 input-base"
-              />
-              <button onClick={() => send(p.code)} className="btn-sm bg-accent text-accent-contrast text-xs">Set</button>
-            </div>
-          ))}
+      {pulseParams.length > 0 && (
+        <div className="mt-4 border-t border-theme-border pt-4">
+          <span className="text-sm font-medium text-theme-text">Pulse Configuration</span>
+          <p className="text-xs text-theme-text/40 mt-1">Set pulse ON to 0 for continuous tone. CS+ defaults to continuous; CS- defaults to 200ms/200ms pulsed.</p>
+          <div className="grid gap-2 sm:grid-cols-2 mt-3">
+            {pulseParams.map((p) => (
+              <div key={p.code} className="flex items-center gap-2">
+                <label className="text-sm flex-1 text-theme-text/60">{labelForCode(p.code, specs)}:</label>
+                <input
+                  type="number"
+                  value={values[p.code] ?? 0}
+                  min={0} max={60000}
+                  onChange={(e) => update(p.code, +e.target.value)}
+                  className="w-20 input-base"
+                />
+                <button onClick={() => send(p.code)} className="btn-sm bg-accent text-accent-contrast text-xs">Set</button>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* ITI Configuration */}
-      <div className="mt-4 border-t border-theme-border pt-4">
-        <span className="text-sm font-medium text-theme-text">ITI Distribution</span>
-        {!itiValid && (
-          <p className="text-xs text-red-500 mt-1">ITI values must satisfy: Min &le; Mean &le; Max (all &ge; 0, Max &gt; 0)</p>
-        )}
-        <div className="grid gap-2 mt-3">
-          <div className="flex items-center gap-2">
-            <label className="text-sm flex-1 text-theme-text/60">ITI Mean (ms):</label>
-            <input
-              type="number"
-              value={itiMean} min={0} max={600000}
-              onChange={(e) => setItiMean(+e.target.value)}
-              className="w-24 input-base"
-            />
-            <button
-              onClick={() => getClientForSession(sessionId)?.sendCommand(sessionId,216, itiMean)}
-              disabled={!itiValid}
-              className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50"
-            >
-              Set
-            </button>
-          </div>
-          <div className="flex items-center gap-2">
-            <label className="text-sm flex-1 text-theme-text/60">ITI Min (ms):</label>
-            <input
-              type="number"
-              value={itiMin} min={0} max={600000}
-              onChange={(e) => setItiMin(+e.target.value)}
-              className="w-24 input-base"
-            />
-            <button
-              onClick={() => getClientForSession(sessionId)?.sendCommand(sessionId,217, itiMin)}
-              disabled={!itiValid}
-              className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50"
-            >
-              Set
-            </button>
-          </div>
-          <div className="flex items-center gap-2">
-            <label className="text-sm flex-1 text-theme-text/60">ITI Max (ms):</label>
-            <input
-              type="number"
-              value={itiMax} min={0} max={600000}
-              onChange={(e) => setItiMax(+e.target.value)}
-              className="w-24 input-base"
-            />
-            <button
-              onClick={() => getClientForSession(sessionId)?.sendCommand(sessionId,218, itiMax)}
-              disabled={!itiValid}
-              className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50"
-            >
-              Set
-            </button>
+      {itiPresent && (
+        <div className="mt-4 border-t border-theme-border pt-4">
+          <span className="text-sm font-medium text-theme-text">ITI Distribution</span>
+          {!itiValid && (
+            <p className="text-xs text-red-500 mt-1">ITI values must satisfy: Min &le; Mean &le; Max (all &ge; 0, Max &gt; 0)</p>
+          )}
+          <div className="grid gap-2 mt-3">
+            <div className="flex items-center gap-2">
+              <label className="text-sm flex-1 text-theme-text/60">ITI Mean (ms):</label>
+              <input
+                type="number"
+                value={itiMean} min={0} max={600000}
+                onChange={(e) => setItiMean(+e.target.value)}
+                className="w-24 input-base"
+              />
+              <button
+                onClick={() => getClientForSession(sessionId)?.sendCommand(sessionId, ITI_MEAN, itiMean)}
+                disabled={!itiValid}
+                className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50"
+              >
+                Set
+              </button>
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-sm flex-1 text-theme-text/60">ITI Min (ms):</label>
+              <input
+                type="number"
+                value={itiMin} min={0} max={600000}
+                onChange={(e) => setItiMin(+e.target.value)}
+                className="w-24 input-base"
+              />
+              <button
+                onClick={() => getClientForSession(sessionId)?.sendCommand(sessionId, ITI_MIN, itiMin)}
+                disabled={!itiValid}
+                className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50"
+              >
+                Set
+              </button>
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-sm flex-1 text-theme-text/60">ITI Max (ms):</label>
+              <input
+                type="number"
+                value={itiMax} min={0} max={600000}
+                onChange={(e) => setItiMax(+e.target.value)}
+                className="w-24 input-base"
+              />
+              <button
+                onClick={() => getClientForSession(sessionId)?.sendCommand(sessionId, ITI_MAX, itiMax)}
+                disabled={!itiValid}
+                className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50"
+              >
+                Set
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/program/pavLabels.ts
+++ b/web/src/components/program/pavLabels.ts
@@ -1,0 +1,49 @@
+import type { CommandSpec } from "../../types";
+
+/**
+ * Pavlovian parameter labels and code groupings.
+ *
+ * The set of Pavlovian params is sourced dynamically from reacher's command
+ * registry (GET /hardware/{id}/commands). This file only supplies presentation
+ * concerns the registry doesn't carry: curated short labels and the UI groupings
+ * (ITI block, pulse block) that have special rendering/validation.
+ *
+ * LABEL_OVERRIDES is intentionally non-load-bearing: a code missing here falls
+ * back to the registry's `description`, then to `Code <n>`. A new registry param
+ * therefore appears in the UI automatically — it just gets its description as a
+ * label until someone adds a nicer override here.
+ */
+export const LABEL_OVERRIDES: Record<number, string> = {
+  206: "CS+ Reward Prob (%)",
+  207: "CS- Reward Prob (%)",
+  208: "CS+ Count",
+  209: "CS- Count",
+  210: "CS+ Frequency (Hz)",
+  211: "CS- Frequency (Hz)",
+  212: "Counterbalance",
+  213: "Cue Duration (ms)",
+  214: "Trace Interval (ms)",
+  215: "Consumption Window (ms)",
+  216: "ITI Mean (ms)",
+  217: "ITI Min (ms)",
+  218: "ITI Max (ms)",
+  219: "Pulse Config",
+  374: "CS+ Pulse On (ms)",
+  375: "CS+ Pulse Off (ms)",
+  384: "CS- Pulse On (ms)",
+  385: "CS- Pulse Off (ms)",
+};
+
+/** ITI distribution codes — rendered as a dedicated min/mean/max block. */
+export const ITI_CODES = [216, 217, 218] as const;
+
+/** Pulse-configuration codes — rendered as a dedicated block (0 = continuous). */
+export const PULSE_CODES = [374, 375, 384, 385] as const;
+
+/** Resolve a display label for a Pavlovian command code. */
+export function labelForCode(code: number, specs: CommandSpec[]): string {
+  if (LABEL_OVERRIDES[code]) return LABEL_OVERRIDES[code];
+  const spec = specs.find((s) => s.code === code);
+  if (spec?.description) return spec.description;
+  return `Code ${code}`;
+}

--- a/web/src/components/program/presets/pavlovianPresets.ts
+++ b/web/src/components/program/presets/pavlovianPresets.ts
@@ -63,10 +63,13 @@ export const PAV_ACQUISITION_PRESET: SessionPreset = {
     207: 0,     // CS- Reward Prob (%)
     208: 50,    // CS+ Count
     209: 50,    // CS- Count
+    212: 0,     // Counterbalance (off)
     214: 1000,  // Trace Interval (ms)
+    215: 5000,  // Consumption Window (ms)
     216: 30000, // ITI Mean (ms)
     217: 20000, // ITI Min (ms)
     218: 50000, // ITI Max (ms)
+    219: 0,     // Pulse Config
     374: 0,     // CS+ Pulse On (ms) — continuous
     375: 0,     // CS+ Pulse Off (ms)
     384: 200,   // CS- Pulse On (ms)
@@ -93,10 +96,13 @@ export const PAV_REVERSAL_PRESET: SessionPreset = {
     207: 100,   // CS- Reward Prob (%) — reversed
     208: 50,    // CS+ Count
     209: 50,    // CS- Count
+    212: 0,     // Counterbalance (off)
     214: 1000,  // Trace Interval (ms)
+    215: 5000,  // Consumption Window (ms)
     216: 30000, // ITI Mean (ms)
     217: 20000, // ITI Min (ms)
     218: 50000, // ITI Max (ms)
+    219: 0,     // Pulse Config
     374: 0,     // CS+ Pulse On (ms) — continuous
     375: 0,     // CS+ Pulse Off (ms)
     384: 200,   // CS- Pulse On (ms)


### PR DESCRIPTION
## Intent
reacher un-deprecated three Pavlovian command params — PAV_COUNTERBALANCE (212, bool), PAV_CONSUMPTION (215, int), PAV_PULSE_CONFIG (219, int) — that the firmware always implemented but the registry had hidden since the v2.0.0 import. labrynth's Pavlovian UI never rendered them. Rather than hardcode three more codes, this fixes the root cause: labrynth hardcoded the Pavlovian param list in several places, so it drifted from reacher's registry on every change (212/215/219 are just the latest case).

## Approach the AI took
Both the web panel and the CLI menu now source the Pavlovian param list dynamically from reacher's existing `GET /api/hardware/{id}/commands` endpoint (already paradigm-filtered and deprecation-stripped server-side), instead of hardcoding it.
- **web:** `PavlovianSettings.tsx` fetches the command specs, partitions them into scalar / pulse / ITI groups by explicit code sets, and renders each scalar by `payload_type` — **212 as a checkbox/toggle**, ints as numeric inputs. The ITI min≤mean≤max validation and the pulse block are preserved. New `pavLabels.ts` holds a shared, non-load-bearing label-override map (degrades to the registry `description`) plus the `ITI_CODES`/`PULSE_CODES` sets. `SessionStartModal.tsx` reuses that map for its start summary; `mock.ts` `getCommands` returns a Pavlovian spec set so demo mode still renders; presets seed `212:0, 215:5000, 219:0` (215 ≥1 per the backend's `duration` bound).
- **cli:** `SessionState` caches `pav_commands` fetched once the paradigm is known; `_pavlovian_menu` renders from that cache (bool → Off/On select, int → numeric prompt) with a reload fallback.

reacher needs no production change — the endpoint already returns everything. A contract test (212→`enabled`/bool, 215→`duration`/int, 219→`config`/int) was added on the reacher side on branch `fix/21-pav-command-registry` (not part of this PR).

## Risk
Frontend/CLI-only; relies on the implicit contract that codes 206–219 are Pavlovian scalars and 374/375/384/385 are pulse. No reacher runtime change. Stored sessions predating 212/215/219 fall back to defaults.

## Not tested
No live end-to-end run (reacher simulator + dev server) was performed — verification was tsc/vite build (passes), CLI py_compile (passes), and reacher's command tests on `fix/21-pav-command-registry` (30 pass). Demo-mode mock render and the 212 toggle were not exercised in a browser.

Closes #59
