### PR TITLE
ci(release): publish stable-named installer aliases for latest downloads

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -368,6 +368,18 @@ jobs:
       - name: List artifacts
         run: ls -lhR artifacts/
 
+      # Stable-named copies so phoxel-workbench can link directly to
+      # releases/latest/download/labrynth-<os>.<ext> (versioned names embed the
+      # release version and would 404 as a "latest" link). The existing *.exe /
+      # *.dmg / *.deb / *.AppImage globs below attach these automatically.
+      - name: Create stable-named aliases for latest downloads
+        run: |
+          cd artifacts
+          cp labrynth-*-windows-x64.exe    labrynth-windows-x64.exe
+          cp labrynth-*-macos-arm64.dmg    labrynth-macos-arm64.dmg
+          cp labrynth-*-linux-x64.AppImage labrynth-linux-x64.AppImage
+          cp labrynth_*_amd64.deb          labrynth-linux-x64.deb
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Intent
phoxel-workbench's Labrynth page wants one-click `releases/latest/download/<asset>` buttons, but our installer assets embed the version (`labrynth-<v>-windows-x64.exe`), so a static "latest" link 404s on every release. This publishes stable-named alias copies alongside the versioned assets so external sites can link directly.

## Approach the AI took
In `build-installers.yml`, the `release` job gains one step (between "List artifacts" and "Create GitHub Release") that `cp`s each versioned installer to a stable name: `labrynth-windows-x64.exe`, `labrynth-macos-arm64.dmg`, `labrynth-linux-x64.AppImage`, `labrynth-linux-x64.deb`. The existing extension globs (`*.exe`/`*.dmg`/`*.deb`/`*.AppImage`) attach them automatically — no `files:` change. Versioned assets are unchanged. `build-prerelease.yml` is untouched (prereleases are excluded from `releases/latest`).

## Risk
`cp` globs assume exactly one versioned source per pattern; if a future build emits multiple arch variants the `cp` would clobber or fail. Aliases only appear on tag-triggered releases, not `workflow_dispatch`.

## Not tested
No live release yet contains the aliases, so the end-to-end `302→200` download redirect is unverified. The alias step was validated only via a synthetic `cp` glob test in /tmp, not a real CI run.

Relates to phoxel-workbench#14