### PR TITLE
fix(hardware): HARDWARE CONTROLS contingency & laser cluster (#65–#69 frontend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Hardware Controls: the laser now exposes the shared Any/RH/LH/Independent "Contingent on" menu and an onset-delay field, matching cue/pump ([#67](https://github.com/Otis-Lab-MUSC/labrynth/issues/67), [#69](https://github.com/Otis-Lab-MUSC/labrynth/issues/69))
+- Firmware upload controls top-align so the "Auto-detected" caption no longer shifts the board/paradigm dropdowns and UPLOAD button ([#65](https://github.com/Otis-Lab-MUSC/labrynth/issues/65))
+
+### Fixed
+- Omission and Pavlovian no longer expose invalid press-contingent "Contingent on" options for output devices, nor render a dangling empty "Contingent on" header; a stale RH/LH lever filter is cleared when entering those paradigms ([#66](https://github.com/Otis-Lab-MUSC/labrynth/issues/66), [#68](https://github.com/Otis-Lab-MUSC/labrynth/issues/68))
+
 ---
 
 ## [3.0.0-beta.6] - 2026-06-17

--- a/web/src/components/hardware/ContingencySection.tsx
+++ b/web/src/components/hardware/ContingencySection.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { getClientForSession } from "../../api/sessionClient";
 import { useSessionStore } from "../../store/useSessionStore";
 
@@ -26,6 +27,27 @@ const DELAY_CMD: Record<Props["deviceKey"], number> = {
 export function ContingencySection({ sessionId, deviceKey, paradigm }: Props) {
   const device    = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi[deviceKey]);
   const updateHardwareUi = useSessionStore((s) => s.updateHardwareUi);
+
+  // Press-contingency is invalid for omission (rewards the *absence* of a press) and
+  // pavlovian (stimulus-driven, not operant), so the lever-routing controls are hidden.
+  const showLevers = paradigm !== "pavlovian" && paradigm !== "omission";
+
+  // Clear any previously-set lever routing when switching into a non-press-contingent
+  // paradigm, so no stale RH/LH filter stays active on the device firmware (#66).
+  useEffect(() => {
+    const current = device?.contingency.leverFilter;
+    if (showLevers || !current || current === "none") return;
+    getClientForSession(sessionId)?.sendCommand(sessionId, FILTER_CMD[deviceKey], 0);
+    updateHardwareUi(sessionId, (prev) => ({
+      [deviceKey]: {
+        ...(prev[deviceKey] as NonNullable<typeof device>),
+        contingency: {
+          ...(prev[deviceKey] as NonNullable<typeof device>).contingency,
+          leverFilter: "none" as const,
+        },
+      },
+    }));
+  }, [showLevers, device, sessionId, deviceKey, updateHardwareUi]);
 
   if (!device) return null;
 
@@ -62,14 +84,13 @@ export function ContingencySection({ sessionId, deviceKey, paradigm }: Props) {
     }));
   };
 
-  const showLevers = paradigm !== "pavlovian";
-
   return (
     <div className="border-t border-theme-text/10 pt-2 mt-1 space-y-2">
-      <div className="text-xs font-medium uppercase tracking-wide text-theme-text/60">Contingent on</div>
       {showLevers && (
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs text-theme-text/60">Trigger on:</span>
+        <>
+          <div className="text-xs font-medium uppercase tracking-wide text-theme-text/60">Contingent on</div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs text-theme-text/60">Trigger on:</span>
           {(["none", "rh", "lh"] as const).map((opt) => (
             <button
               key={opt}
@@ -83,7 +104,8 @@ export function ContingencySection({ sessionId, deviceKey, paradigm }: Props) {
               {opt === "none" ? "Any" : opt.toUpperCase()}
             </button>
           ))}
-        </div>
+          </div>
+        </>
       )}
       <div className="flex items-center gap-2">
         <label className="text-xs text-theme-text/60">Delay (ms):</label>

--- a/web/src/components/hardware/LaserControl.tsx
+++ b/web/src/components/hardware/LaserControl.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import { getClientForSession } from "../../api/sessionClient";
 import { useSessionStore } from "../../store/useSessionStore";
+import { LASER_MODE_COMMANDS } from "../program/devicePresets";
 import { PinField } from "./PinField";
 import { SquareWaveCanvas } from "./SquareWaveCanvas";
 
@@ -11,18 +11,20 @@ interface Props {
 
 export function LaserControl({ sessionId, paradigm }: Props) {
   const laser = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi.laser);
-  const rhLever = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi.rhLever);
-  const lhLever = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi.lhLever);
+  const pavParams = useSessionStore((s) => s.sessions.get(sessionId)?.pavlovianParams);
   const updateHardwareUi = useSessionStore((s) => s.updateHardwareUi);
-  const [onsetDelay, setOnsetDelay] = useState(0);
 
   if (!laser) return null;
 
-  const { armed, frequency, duration, mode, phase } = laser;
+  const { armed, frequency, duration, mode, phase, contingency, onsetDelay } = laser;
   const send = (code: number, value?: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code, value);
   const isPavlovian = paradigm === "pavlovian";
 
-  const activeLeverLabel = rhLever?.armed ? "RH" : lhLever?.armed ? "LH" : null;
+  // In Pavlovian the laser fires within a single trial phase, so cap the onset delay to that
+  // phase window (cue=213, consumption=215) — firmware clamps too, this keeps the UI honest (#69).
+  const delayMax = isPavlovian
+    ? Math.max(0, (phase === "cue" ? (pavParams?.[213] ?? 2000) : (pavParams?.[215] ?? 5000)) - 1)
+    : 600000;
 
   return (
     <div className="card">
@@ -86,37 +88,21 @@ export function LaserControl({ sessionId, paradigm }: Props) {
           )}
         </>
       ) : (
-        <>
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm text-theme-text/60">Mode:</span>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-theme-text/60">Contingent on:</span>
+          {([
+            ["any", "Any", LASER_MODE_COMMANDS.contingent],
+            ["rh", "RH", LASER_MODE_COMMANDS.rh_lever],
+            ["lh", "LH", LASER_MODE_COMMANDS.lh_lever],
+            ["independent", "Independent", LASER_MODE_COMMANDS.independent],
+          ] as const).map(([val, label, cmd]) => (
             <button
-              onClick={() => { send(681); updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, mode: "contingent" } })); }}
-              className={`btn-sm ${mode === "contingent" ? "bg-purple-600" : "bg-purple-600/40"} text-white`}
-            >Active + Cue</button>
-            <button
-              onClick={() => { send(684); updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, mode: "rh_lever" } })); }}
-              className={`btn-sm ${mode === "rh_lever" ? "bg-purple-600" : "bg-purple-600/40"} text-white`}
-            >RH Only</button>
-            <button
-              onClick={() => { send(682); updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, mode: "independent" } })); }}
-              className={`btn-sm ${mode === "independent" ? "bg-purple-500" : "bg-purple-500/40"} text-white`}
-            >Independent</button>
-          </div>
-          {mode === "contingent" && activeLeverLabel && (
-            <span className="text-xs text-theme-text/50">Contingent on: {activeLeverLabel} lever</span>
-          )}
-          {mode === "rh_lever" && (
-            <div className="flex items-center gap-2">
-              <label className="text-sm text-theme-text/60">Onset delay (ms):</label>
-              <input type="number" value={onsetDelay} min={0} max={60000}
-                onChange={(e) => setOnsetDelay(+e.target.value)}
-                className="w-24 input-base" />
-              <button onClick={() => send(673, onsetDelay)}
-                disabled={onsetDelay < 0 || onsetDelay > 60000}
-                className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
-            </div>
-          )}
-        </>
+              key={val}
+              onClick={() => { send(cmd); updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, contingency: val } })); }}
+              className={`btn-sm ${contingency === val ? "bg-purple-600" : "bg-purple-600/40"} text-white`}
+            >{label}</button>
+          ))}
+        </div>
       )}
       <div className="flex items-center gap-2">
         <label className="text-sm text-theme-text/60" title="Integer ms timing causes ~2-4% error at 30/40 Hz. Exact at 1, 10, 20, 25, 50 Hz.">Freq (Hz):</label>
@@ -134,6 +120,15 @@ export function LaserControl({ sessionId, paradigm }: Props) {
           className="w-24 input-base" />
         <button onClick={() => send(672, duration)}
           disabled={duration < 1 || duration > 600000}
+          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-sm text-theme-text/60" title="Onset delay from trigger to laser activation">Delay (ms):</label>
+        <input type="number" value={onsetDelay} min={0} max={delayMax}
+          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, onsetDelay: Math.min(Math.max(0, +e.target.value), delayMax) } }))}
+          className="w-24 input-base" />
+        <button onClick={() => send(673, onsetDelay)}
+          disabled={onsetDelay < 0 || onsetDelay > delayMax}
           className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
       </div>
       <SquareWaveCanvas frequency={frequency} duration={duration} />

--- a/web/src/components/program/devicePresets.ts
+++ b/web/src/components/program/devicePresets.ts
@@ -23,9 +23,9 @@ export const DEVICE_PRESETS: DevicePreset[] = [
   // },
 ];
 
-/** Command code for laser mode: contingent = 681, independent = 682, rh_lever = 684, Pavlovian trial types = 691-693 */
+/** Command code for laser mode: contingent(Any) = 681, independent = 682, rh_lever = 684, lh_lever = 685, Pavlovian trial types = 691-693 */
 export const LASER_MODE_COMMANDS = {
-  contingent: 681, independent: 682, rh_lever: 684,
+  contingent: 681, independent: 682, rh_lever: 684, lh_lever: 685,
   cs_plus: 691, cs_minus: 692, cs_both: 693,
 } as const;
 
@@ -39,7 +39,7 @@ export const PRESET_COMMAND_MAP: Record<string, { arm: number; disarm: number; p
   secondaryCue:  { arm: 311,  disarm: 310,  params: { frequency: 381, duration: 382, leverFilter: 388, delay: 387 } },
   primaryPump:   { arm: 401,  disarm: 400,  params: { duration: 472,  leverFilter: 478, delay: 477 } },
   secondaryPump: { arm: 411,  disarm: 410,  params: { duration: 482,  leverFilter: 488, delay: 487 } },
-  laser:         { arm: 601,  disarm: 600,  params: { frequency: 671, duration: 672 } },
+  laser:         { arm: 601,  disarm: 600,  params: { frequency: 671, duration: 672, delay: 673 } },
   lickCircuit:   { arm: 501,  disarm: 500 },
   microscope:    { arm: 901,  disarm: 900 },
   slm:           { arm: 1101, disarm: 1100 },

--- a/web/src/components/program/presets/frSaPresets.ts
+++ b/web/src/components/program/presets/frSaPresets.ts
@@ -35,7 +35,7 @@ const PUMP_HARDWARE: Partial<HardwareUiState> = {
 };
 
 const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
-  laser:        { armed: false, frequency: 40, duration: 5000, mode: "contingent" as const },
+  laser:        { armed: false, frequency: 40, duration: 5000, mode: "contingent" as const, contingency: "any" as const, onsetDelay: 0 },
   lickCircuit:  { armed: false },
   microscope:   { armed: false, frameRate: null, frameAveraging: null },
   slm:          { armed: false, pin: 11 },

--- a/web/src/components/program/presets/pavlovianPresets.ts
+++ b/web/src/components/program/presets/pavlovianPresets.ts
@@ -28,7 +28,7 @@ const CORE_HARDWARE: Partial<HardwareUiState> = {
 };
 
 const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
-  laser:       { armed: false, frequency: 40, duration: 5000, mode: "cs_plus" as const, phase: "reward" as const },
+  laser:       { armed: false, frequency: 40, duration: 5000, mode: "cs_plus" as const, phase: "reward" as const, contingency: "any" as const, onsetDelay: 0 },
   lickCircuit: { armed: true },
   microscope:  { armed: false, frameRate: null, frameAveraging: null },
   slm:         { armed: false, pin: 11 },
@@ -54,7 +54,7 @@ export const PAV_ACQUISITION_PRESET: SessionPreset = {
   hardware: {
     ...CORE_HARDWARE,
     ...OPTIONAL_HARDWARE,
-    laser: { armed: true, frequency: 40, duration: 5000, mode: "cs_plus" as const, phase: "reward" as const },
+    laser: { armed: true, frequency: 40, duration: 5000, mode: "cs_plus" as const, phase: "reward" as const, contingency: "any" as const, onsetDelay: 0 },
     lickCircuit: { armed: true },
   },
   paradigmSettings: PARADIGM_SETTINGS,
@@ -87,7 +87,7 @@ export const PAV_REVERSAL_PRESET: SessionPreset = {
   hardware: {
     ...CORE_HARDWARE,
     ...OPTIONAL_HARDWARE,
-    laser: { armed: true, frequency: 40, duration: 5000, mode: "cs_plus" as const, phase: "reward" as const },
+    laser: { armed: true, frequency: 40, duration: 5000, mode: "cs_plus" as const, phase: "reward" as const, contingency: "any" as const, onsetDelay: 0 },
     lickCircuit: { armed: true },
   },
   paradigmSettings: PARADIGM_SETTINGS,

--- a/web/src/components/session/FirmwareUploadCard.tsx
+++ b/web/src/components/session/FirmwareUploadCard.tsx
@@ -34,7 +34,7 @@ export function FirmwareUploadCard({ sessionId, detectedBoard }: Props) {
   return (
     <div className="card">
       <h3 className="font-medium text-theme-text">Firmware Upload</h3>
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         <div className="flex flex-col gap-0.5">
           <select
             value={selectedBoard}

--- a/web/src/store/useSessionStore.ts
+++ b/web/src/store/useSessionStore.ts
@@ -52,7 +52,7 @@ export const defaultHardwareUiState = (): HardwareUiState => ({
   secondaryCue: { armed: false, frequency: 2900, duration: 1000, contingency: DEFAULT_CONTINGENCY() },
   primaryPump:  { armed: false, duration: 3000, contingency: DEFAULT_CONTINGENCY() },
   secondaryPump: { armed: false, duration: 3000, contingency: DEFAULT_CONTINGENCY() },
-  laser: { armed: false, frequency: 40, duration: 5000, mode: "contingent", phase: "reward" },
+  laser: { armed: false, frequency: 40, duration: 5000, mode: "contingent", phase: "reward", contingency: "any", onsetDelay: 0 },
   lickCircuit: { armed: false },
   microscope: { armed: false, frameRate: null, frameAveraging: null },
   slm: { armed: false, pin: 11 },

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -51,6 +51,8 @@ export interface LaserUiState extends DeviceArmState {
   duration: number;
   mode: "contingent" | "independent" | "rh_lever" | "cs_plus" | "cs_minus" | "cs_both";
   phase?: "reward" | "cue";  // Pavlovian only — which trial phase triggers laser
+  contingency: "any" | "rh" | "lh" | "independent";  // operant lever routing (#67)
+  onsetDelay: number;  // ms from trigger to laser onset (#67/#69)
 }
 
 export interface MicroscopeUiState extends DeviceArmState {


### PR DESCRIPTION
## Intent
Five beta.6 bugs clustered in the HARDWARE CONTROLS panel and paradigm-aware UI gating:
- #65 — firmware-upload "Auto-detected" caption breaks baseline alignment of the board dropdown vs paradigm dropdown vs UPLOAD button.
- #66 — omission wrongly exposes press-contingent "CONTINGENT ON" options for output devices.
- #67 — laser lacks the shared Any/RH/LH/Independent contingency menu + delay field that cue/pump expose (frontend half).
- #68 — pavlovian renders a dangling empty "CONTINGENT ON" header.
- #69 — pavlovian laser missing the onset-delay field (frontend half).

## Approach the AI took
- **#65:** row `items-center` → `items-start` so the caption hangs below without re-centering/shifting the equal-height controls.
- **#66/#68:** `showLevers` now also excludes `omission`; the "Contingent on" header moved inside the gate so no empty header renders; a `useEffect` clears a stale RH/LH `leverFilter` (sends filter=0) when entering a non-press-contingent paradigm. Delay field stays unconditional.
- **#67/#69:** `LaserUiState` gains persisted `contingency` ("any"|"rh"|"lh"|"independent") + `onsetDelay`. Operant laser gets a 4-way "Contingent on" menu (Any→681, RH→684, LH→685, Independent→682); a Delay field (cmd 673) renders for both operant and Pavlovian. In Pavlovian the Delay input is capped to the active phase window (cue=param 213, consumption=param 215). Preset/store literals updated to the new shape.

Pairs with firmware PR REACHER_PR_PLACEHOLDER for #67/#69.

## Risk
- `cross_repo`: #67/#69 only work end-to-end once the paired reacher PR (cmds 685, 673, Pavlovian onset) merges; on current firmware, RH/LH/673 calls would 006-error harmlessly.
- The `useEffect` lever-filter reset issues one firmware command on paradigm entry — low risk, mirrors existing filter sends.
- No data-integrity/security surface; pure UI + command-dispatch changes.

## Not tested
- No hardware: not run against a board, so the new 685/673 ACKs and on-screen behavior are TypeScript/build-verified only.
- `npm run build` (tsc + vite) passes clean; repo-wide `npm run lint` is broken pre-existing (ESLint v9 can't find config) and was not run.
- Manual paradigm walkthrough in `npm run dev` not performed in this environment.

Closes #65
Closes #66
Closes #68
Refs #67, #69
