### PR TITLE
task: bump stock GitHub Actions to Node 24 runtime versions across REACHER-Suite workflows

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -29,10 +29,10 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -57,15 +57,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -118,7 +118,7 @@ jobs:
         run: iscc installer\reacher.iss
 
       - name: Upload installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-installer
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-windows-x64.exe
@@ -130,7 +130,7 @@ jobs:
         run: tar -czf "dist/labrynth-cli-${VERSION}-windows-x64.tar.gz" -C dist LabrynthCLI
 
       - name: Upload CLI bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-cli
           path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-windows-x64.tar.gz
@@ -143,15 +143,15 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -191,7 +191,7 @@ jobs:
             "dist/labrynth-${VERSION}-macos-arm64.dmg"
 
       - name: Upload DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-arm64-dmg
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-macos-arm64.dmg
@@ -202,7 +202,7 @@ jobs:
         run: tar -czf "dist/labrynth-cli-${VERSION}-macos-arm64.tar.gz" -C dist LabrynthCLI
 
       - name: Upload CLI bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-arm64-cli
           path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-macos-arm64.tar.gz
@@ -215,15 +215,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -342,7 +342,7 @@ jobs:
           ARCH=x86_64 ./appimagetool --no-appstream "${APPDIR}" "labrynth-${VERSION}-linux-x64.AppImage"
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-installers
           path: |
@@ -360,7 +360,7 @@ jobs:
     if: github.ref_type == 'tag'
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -29,10 +29,10 @@ jobs:
       reacher_ref_source: ${{ steps.reacher_ref.outputs.source }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -88,15 +88,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -150,7 +150,7 @@ jobs:
         run: iscc installer\reacher.iss
 
       - name: Upload installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-installer
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-windows-x64.exe
@@ -162,7 +162,7 @@ jobs:
         run: tar -czf "dist/labrynth-cli-${VERSION}-windows-x64.tar.gz" -C dist LabrynthCLI
 
       - name: Upload CLI bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-cli
           path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-windows-x64.tar.gz
@@ -176,15 +176,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -225,7 +225,7 @@ jobs:
             "dist/labrynth-${VERSION}-macos-arm64.dmg"
 
       - name: Upload DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-arm64-dmg
           path: dist/labrynth-${{ needs.version-check.outputs.version }}-macos-arm64.dmg
@@ -236,7 +236,7 @@ jobs:
         run: tar -czf "dist/labrynth-cli-${VERSION}-macos-arm64.tar.gz" -C dist LabrynthCLI
 
       - name: Upload CLI bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-arm64-cli
           path: dist/labrynth-cli-${{ needs.version-check.outputs.version }}-macos-arm64.tar.gz
@@ -250,15 +250,15 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -378,7 +378,7 @@ jobs:
           ARCH=x86_64 ./appimagetool --no-appstream "${APPDIR}" "labrynth-${VERSION}-linux-x64.AppImage"
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-installers
           path: |
@@ -398,7 +398,7 @@ jobs:
     if: always() && github.ref_type == 'tag' && needs.version-check.result == 'success'
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -19,9 +19,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -40,12 +40,12 @@ jobs:
           # downstream consumer (see web/README.md "Embeddable demo artifact").
           VITE_BASE: ./
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: web/dist
 
       - name: Upload embeddable demo artifact (path-agnostic, base=./)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: labrynth-demo
           path: web/dist
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Intent
GitHub is deprecating the Node 20 Actions runtime; our workflows emit
"Node.js 20 is deprecated … forced to run on Node.js 24" annotations.
This bumps all stock `actions/*` to their latest majors on the node24
runtime to clear the warnings before they become hard failures.

## Approach the AI took
Pure version-string bumps across the three labrynth workflows
(`build-installers.yml`, `build-prerelease.yml`, `deploy-demo.yml`):
checkout v4→v7, setup-node v4→v6, setup-python v5→v6, upload-artifact
v4→v7, download-artifact v4→v8, upload-pages-artifact v3→v5,
deploy-pages v4→v5. Targeted the latest major per the issue's "latest
major that targets node24"; confirmed each `runs.using: node24`. No
logic/input changes — verified the cross-job artifact flow (unique
upload names + name-less `merge-multiple` download) is still supported
in download-artifact v8. 39 lines changed, 1:1.

## Risk
Low. Multi-major bumps (bigger than the issue assumed v4→v5) widen the
breaking-change surface, mainly in upload/download-artifact — but inputs
were verified backward-compatible and our usage is the standard pattern.
deploy-pages v4→v5 was included though the issue listed it only under
phoxel-workbench (it was node20 in deploy-demo.yml). Real proof is the
next workflow run after merge.

## Not tested
Workflows not executed — no local Act run. download-artifact v8
`merge-multiple` compatibility confirmed by reading the action's inputs,
not by a live run. AC ("no Node 20 annotation") verifiable only on the
next CI run.

This PR covers the **labrynth** workflows only; the phoxel-workbench
`deploy-site.yml` portion of #63 is tracked separately.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)