### PR TITLE
task: bump softprops/action-gh-release from v2 to v3 (clear last Node 20 deprecation)

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -381,7 +381,7 @@ jobs:
           cp labrynth_*_amd64.deb          labrynth-linux-x64.deb
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           prerelease: false

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -407,7 +407,7 @@ jobs:
         run: ls -lhR artifacts/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           VERSION: ${{ needs.version-check.outputs.version }}
           REACHER_REF: ${{ needs.version-check.outputs.reacher_ref }}


### PR DESCRIPTION
## Intent
Clear the last "Node.js 20 is deprecated" annotation in labrynth's release workflows. Follow-up to #63, which bumped all `actions/*` stock actions to node24 majors but deliberately left third-party actions out of scope. The `v3.0.0-beta.10` release run confirmed `actions/*` are clean; only `softprops/action-gh-release@v2` (node20) remained.

## Approach the AI took
Two one-line version bumps: `softprops/action-gh-release@v2` → `@v3` in `build-installers.yml:384` and `build-prerelease.yml:410`. v2 targets the node20 runtime; the latest v3 (v3.0.1) targets node24. No functional change to the release step — same inputs, asset list, and prerelease flag logic.

## Risk
Low. action-gh-release v2→v3 is a major bump, but our usage is the standard release-creation pattern; v3's inputs are backward-compatible. The release step's behavior (assets, naming, prerelease flag) is unchanged. Real proof is the next release run.

## Not tested
Not exercised by a workflow run — build-installers/build-prerelease only fire on release tags. Verifies on the next labrynth release (no Node 20 annotation; release publishes with assets intact). No throwaway tag cut just for this.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)