### PR TITLE
fix(monitor): show all configured hardware in session start summary (#78)

### DIFF
--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -7,51 +7,12 @@ import { getClientForSession } from "../../api/sessionClient";
 import { PRESET_COMMAND_MAP, LASER_MODE_COMMANDS, PAV_LASER_PHASE_COMMANDS } from "../program/devicePresets";
 import { ParadigmFlowDiagram } from "./ParadigmFlowDiagram";
 import { ValidationWarningPanel } from "./ValidationWarningPanel";
+import { DEVICE_LABELS, formatDeviceParams } from "./hardwareSummary";
 import type { ValidationResult } from "../../api/client";
 
 // Shared with PavlovianSettings so the start-summary labels every param the
 // registry can surface (incl. re-enabled 212/215/219), with no separate drift.
 import { LABEL_OVERRIDES as PAV_CODE_LABELS } from "../program/pavLabels";
-
-const DEVICE_LABELS: Record<string, string> = {
-  rhLever: "RH Lever",
-  lhLever: "LH Lever",
-  primaryCue: "Cue 1",
-  secondaryCue: "Cue 2",
-  primaryPump: "Pump 1",
-  secondaryPump: "Pump 2",
-  laser: "Laser",
-  lickCircuit: "Lick Circuit",
-  microscope: "Microscope",
-};
-
-function formatDeviceParams(key: string, device: Record<string, unknown>, isPav: boolean): string {
-  const parts: string[] = [];
-  if ("timeout" in device && device.timeout !== undefined) parts.push(`T:${Number(device.timeout) / 1000}s`);
-  if ("ratio" in device && device.ratio !== undefined) parts.push(`R:${device.ratio}`);
-  if ("frequency" in device && device.frequency !== undefined) parts.push(`${device.frequency}Hz`);
-  if ("duration" in device && device.duration !== undefined) {
-    const durStr = `${device.duration}ms`;
-    parts.push(durStr);
-  }
-  // Laser-specific: mode and phase
-  if (key === "laser") {
-    const mode = device.mode as string | undefined;
-    if (mode === "independent") {
-      parts.push("Independent");
-    } else if (mode) {
-      const filterLabel: Record<string, string> = {
-        contingent: "Contingent", cs_plus: "CS+", cs_minus: "CS\u2212", cs_both: "CS\u00B1",
-      };
-      parts.push(`Trial-Paired (${filterLabel[mode] ?? mode})`);
-    }
-    if (isPav && mode !== "independent" && device.phase) {
-      const phaseLabel: Record<string, string> = { reward: "Reward", cue: "Cue" };
-      parts.push(`Phase: ${phaseLabel[device.phase as string] ?? device.phase}`);
-    }
-  }
-  return parts.join("  ");
-}
 
 export function SessionStartModal() {
   const startModalOpen = useSessionStore((s) => s.startModalOpen);
@@ -78,6 +39,9 @@ export function SessionStartModal() {
 
   const paradigm = session?.paradigm?.toLowerCase();
   const isPavlovian = paradigm === "pavlovian";
+  // Press-contingent (operant, non-omission) gates lever-routing display, mirroring
+  // ContingencySection's `showLevers` so the summary matches where it's configurable.
+  const pressContingent = !isPavlovian && paradigm !== "omission";
 
   // Sync local state when modal opens or session changes
   useEffect(() => {
@@ -365,7 +329,7 @@ export function SessionStartModal() {
                         )}
                       </td>
                       <td className="px-3 py-1.5 font-mono text-xs text-theme-text/60">
-                        {state.armed ? formatDeviceParams(key, state as Record<string, unknown>, isPavlovian) : ""}
+                        {state.armed ? formatDeviceParams(key, state as Record<string, unknown>, { isPav: isPavlovian, pressContingent }) : ""}
                       </td>
                     </tr>
                   ))}

--- a/web/src/components/monitor/hardwareSummary.ts
+++ b/web/src/components/monitor/hardwareSummary.ts
@@ -1,0 +1,128 @@
+import type {
+  HardwareUiState,
+  LeverUiState,
+  CueUiState,
+  PumpUiState,
+  LaserUiState,
+  MicroscopeUiState,
+  SlmUiState,
+  DeviceArmState,
+} from "../../types";
+
+// Display labels for every device surfaced in the start-summary Hardware table.
+export const DEVICE_LABELS: Record<string, string> = {
+  rhLever: "RH Lever",
+  lhLever: "LH Lever",
+  primaryCue: "Cue 1",
+  secondaryCue: "Cue 2",
+  primaryPump: "Pump 1",
+  secondaryPump: "Pump 2",
+  laser: "Laser",
+  lickCircuit: "Lick Circuit",
+  microscope: "Microscope",
+  slm: "SLM",
+};
+
+export interface SummaryContext {
+  /** Pavlovian paradigm — drives laser mode/phase display and hides press-contingency. */
+  isPav: boolean;
+  /** Paradigm is press-contingent (operant, non-omission) — gates lever-routing display. */
+  pressContingent: boolean;
+}
+
+// Every device in HardwareUiState except the testMode flag. Keying FORMATTERS by
+// this union as a mapped type makes the summary renderer exhaustive: add a device
+// to HardwareUiState and the build fails here until it gets a formatter — the guard
+// against the summary silently drifting from the configured-hardware schema (#78).
+type SummaryDeviceKey = Exclude<keyof HardwareUiState, "testMode">;
+
+const leverFilterLabel: Record<"rh" | "lh", string> = { rh: "RH", lh: "LH" };
+
+function contingencyParts(c: { leverFilter: "none" | "rh" | "lh"; delay: number }, ctx: SummaryContext): string[] {
+  const parts: string[] = [];
+  if (ctx.pressContingent && c.leverFilter !== "none") parts.push(leverFilterLabel[c.leverFilter]);
+  if (c.delay > 0) parts.push(`Delay:${c.delay}ms`);
+  return parts;
+}
+
+function leverParts(s: LeverUiState): string[] {
+  return [`T:${s.timeout / 1000}s`, `R:${s.ratio}`];
+}
+
+function cueParts(s: CueUiState, ctx: SummaryContext): string[] {
+  return [`${s.frequency}Hz`, `${s.duration}ms`, ...contingencyParts(s.contingency, ctx)];
+}
+
+function pumpParts(s: PumpUiState, ctx: SummaryContext): string[] {
+  return [`${s.duration}ms`, ...contingencyParts(s.contingency, ctx)];
+}
+
+const pavModeLabel: Record<"cs_plus" | "cs_minus" | "cs_both", string> = {
+  cs_plus: "CS+", cs_minus: "CS−", cs_both: "CS±",
+};
+const laserRoutingLabel: Record<LaserUiState["contingency"], string> = {
+  any: "Any", rh: "RH", lh: "LH", independent: "Independent",
+};
+
+function laserParts(s: LaserUiState, ctx: SummaryContext): string[] {
+  const parts: string[] = [`${s.frequency}Hz`, `${s.duration}ms`];
+  if (s.onsetDelay > 0) parts.push(`Delay:${s.onsetDelay}ms`);
+  if (ctx.isPav) {
+    // Pavlovian: `mode` is authoritative (independent vs. trial-paired CS filter) + phase.
+    // Any non-independent mode is trial-paired; only cs_* carry a specific filter label.
+    // The default/leftover modes ("contingent", "rh_lever") must still read as Trial-Paired
+    // rather than silently dropping the routing token (#78).
+    if (s.mode === "independent") {
+      parts.push("Independent");
+    } else if (s.mode === "cs_plus" || s.mode === "cs_minus" || s.mode === "cs_both") {
+      parts.push(`Trial-Paired (${pavModeLabel[s.mode]})`);
+    } else {
+      parts.push("Trial-Paired");
+    }
+    if (s.mode !== "independent" && s.phase) {
+      const phaseLabel: Record<"reward" | "cue", string> = { reward: "Reward", cue: "Cue" };
+      parts.push(`Phase: ${phaseLabel[s.phase]}`);
+    }
+  } else {
+    // Operant: `contingency` is authoritative routing — `mode` is only touched by the
+    // Pavlovian UI and can be stale here, so it must NOT drive the summary (#78).
+    parts.push(`Contingent: ${laserRoutingLabel[s.contingency]}`);
+  }
+  return parts;
+}
+
+function microscopeParts(s: MicroscopeUiState): string[] {
+  const parts: string[] = [];
+  if (s.frameRate != null) parts.push(`${s.frameRate}fps`);
+  if (s.frameAveraging != null) parts.push(`Avg:${s.frameAveraging}`);
+  return parts;
+}
+
+function slmParts(s: SlmUiState): string[] {
+  return [`Pin:${s.pin}`];
+}
+
+// Exhaustive per-device formatters. The mapped-type key set is the drift guard (see above).
+const FORMATTERS: { [K in SummaryDeviceKey]: (state: HardwareUiState[K], ctx: SummaryContext) => string[] } = {
+  rhLever: leverParts,
+  lhLever: leverParts,
+  primaryCue: cueParts,
+  secondaryCue: cueParts,
+  primaryPump: pumpParts,
+  secondaryPump: pumpParts,
+  laser: laserParts,
+  lickCircuit: (_s: DeviceArmState) => [],
+  microscope: microscopeParts,
+  slm: slmParts,
+};
+
+/**
+ * Format an armed device's configured settings for the start-summary Hardware table.
+ * `key` comes from Object.entries(hardwareUi), so the lookup is the one typed boundary;
+ * the FORMATTERS bodies stay fully typed so the exhaustiveness guard holds.
+ */
+export function formatDeviceParams(key: string, state: Record<string, unknown>, ctx: SummaryContext): string {
+  const fn = FORMATTERS[key as SummaryDeviceKey] as ((s: unknown, ctx: SummaryContext) => string[]) | undefined;
+  if (!fn) return "";
+  return fn(state, ctx).join("  ");
+}


### PR DESCRIPTION
## Summary
The **Review Session Configuration** modal — the operator's final confirmation before a session — did not faithfully reflect the configured hardware. Its device renderer (`formatDeviceParams`) only emitted `timeout / ratio / frequency / duration` (+ laser mode/phase), so several operator-set fields were **omitted**, and the laser routing could show a **wrong** value.

Closes #78.

## Root cause (two defects, one renderer)
- **Omission** — never displayed: cue/pump **lever-filter** + **onset delay**, laser **onset delay**, microscope **frame rate / averaging**. SLM rendered with a raw key and no label.
- **Wrong value** — for **operant** paradigms the laser's authoritative routing is `laser.contingency`, but the renderer read `laser.mode` (only updated by the *Pavlovian* UI). After setting an operant routing, the summary could still show a stale `Trial-Paired (CS±)` where the operator had selected `RH`.

## Change
- New `web/src/components/monitor/hardwareSummary.ts` owns `DEVICE_LABELS` + a per-device formatter map **typed over every key of `HardwareUiState` (minus `testMode`)**. The mapped type makes `tsc` fail if a device is added to the schema without a summary formatter — a **compile-time drift guard** so the summary can't silently fall behind the hardware schema again.
- Completed every device's field coverage; made the laser formatter **paradigm-aware** (Pavlovian → `mode`/`phase`, operant → `contingency` routing). Non-independent Pavlovian modes always read as `Trial-Paired` (no silent drop on the default `contingent` mode).
- `SessionStartModal.tsx` now imports the shared module and passes `{ isPav, pressContingent }`; `handleStart`/command-send path is unchanged (display-only).

## Verification
- `npm run build` (`tsc -b && vite build`) green; the drift guard was empirically confirmed to fail the build on device add/remove and on a renamed field a formatter reads.
- `npm run lint` is **pre-existing broken** in this repo (ESLint v9 with no `eslint.config.js`) — unrelated to this change.
- No test framework in labrynth by design (per `CLAUDE.md`); type-check is the gate.

## Reviewed
Four-lens review board (AI-failure / correctness-security / logic / code-rigor). One cross-lens consensus finding (default-mode Pavlovian laser silently dropped its routing token) was fixed before commit.

## Follow-up (out of scope — separate issue recommended)
The review surfaced two *summary-vs-send* divergences in the `handleStart` command path (not the renderer): an `independent` laser with a leftover `phase` still sends a phase command the summary hides; a cue/pump `leverFilter` in omission paradigm is sent but hidden. Those belong to firmware-command-emission behavior, not this display fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)