### PR TITLE
fix(monitor): gate session-start sends on the summary's predicates (#80)

### DIFF
--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -7,7 +7,7 @@ import { getClientForSession } from "../../api/sessionClient";
 import { PRESET_COMMAND_MAP, LASER_MODE_COMMANDS, PAV_LASER_PHASE_COMMANDS } from "../program/devicePresets";
 import { ParadigmFlowDiagram } from "./ParadigmFlowDiagram";
 import { ValidationWarningPanel } from "./ValidationWarningPanel";
-import { DEVICE_LABELS, formatDeviceParams } from "./hardwareSummary";
+import { DEVICE_LABELS, formatDeviceParams, leverFilterActive, laserPhaseActive } from "./hardwareSummary";
 import type { ValidationResult } from "../../api/client";
 
 // Shared with PavlovianSettings so the start-summary labels every param the
@@ -154,9 +154,9 @@ export function SessionStartModal() {
             }
           }
           // leverFilter and delay are nested at state.contingency.* — flat lookup above skips them.
-          const contingency = (state as { contingency?: { leverFilter?: string; delay?: number } }).contingency;
-          if (contingency?.leverFilter && contingency.leverFilter !== "none" && mapping.params.leverFilter !== undefined) {
-            const numVal = contingency.leverFilter === "rh" ? 1 : contingency.leverFilter === "lh" ? 2 : 0;
+          const contingency = (state as { contingency?: { leverFilter?: "none" | "rh" | "lh"; delay?: number } }).contingency;
+          if (leverFilterActive(contingency?.leverFilter, pressContingent) && mapping.params.leverFilter !== undefined) {
+            const numVal = contingency.leverFilter === "rh" ? 1 : 2;
             await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, mapping.params.leverFilter, numVal);
           }
           if (contingency?.delay && contingency.delay > 0 && mapping.params.delay !== undefined) {
@@ -174,7 +174,7 @@ export function SessionStartModal() {
         }
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode as keyof typeof LASER_MODE_COMMANDS]);
       }
-      if (isPavlovian && laserState?.phase) {
+      if (laserPhaseActive(isPavlovian, laserState?.mode, laserState?.phase)) {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase as keyof typeof PAV_LASER_PHASE_COMMANDS]);
       }
 

--- a/web/src/components/monitor/hardwareSummary.ts
+++ b/web/src/components/monitor/hardwareSummary.ts
@@ -38,9 +38,36 @@ type SummaryDeviceKey = Exclude<keyof HardwareUiState, "testMode">;
 
 const leverFilterLabel: Record<"rh" | "lh", string> = { rh: "RH", lh: "LH" };
 
+// Single source of truth for the two gates that the start-summary and the
+// handleStart send-path must agree on (#80). Both the display formatters here and
+// SessionStartModal's command emission derive from these, so what is sent to the
+// firmware can never diverge from what the confirmation modal shows.
+
+/** Lever-routing filter (378/388/478/488) — sent/shown only for press-contingent paradigms. */
+export function leverFilterActive(
+  leverFilter: "none" | "rh" | "lh" | undefined,
+  pressContingent: boolean,
+): leverFilter is "rh" | "lh" {
+  return pressContingent && leverFilter !== undefined && leverFilter !== "none";
+}
+
+/**
+ * Pavlovian laser phase (694/695) — sent/shown only for a Pavlovian, trial-paired
+ * (non-independent) laser with a phase set. `isPav` is encoded in the predicate (not
+ * just asserted at the call site) so the gate is indivisible — mirroring how
+ * `leverFilterActive` carries `pressContingent`.
+ */
+export function laserPhaseActive(
+  isPav: boolean,
+  mode: LaserUiState["mode"] | undefined,
+  phase: "reward" | "cue" | undefined,
+): phase is "reward" | "cue" {
+  return isPav && mode !== "independent" && phase !== undefined;
+}
+
 function contingencyParts(c: { leverFilter: "none" | "rh" | "lh"; delay: number }, ctx: SummaryContext): string[] {
   const parts: string[] = [];
-  if (ctx.pressContingent && c.leverFilter !== "none") parts.push(leverFilterLabel[c.leverFilter]);
+  if (leverFilterActive(c.leverFilter, ctx.pressContingent)) parts.push(leverFilterLabel[c.leverFilter]);
   if (c.delay > 0) parts.push(`Delay:${c.delay}ms`);
   return parts;
 }
@@ -79,7 +106,7 @@ function laserParts(s: LaserUiState, ctx: SummaryContext): string[] {
     } else {
       parts.push("Trial-Paired");
     }
-    if (s.mode !== "independent" && s.phase) {
+    if (laserPhaseActive(ctx.isPav, s.mode, s.phase)) {
       const phaseLabel: Record<"reward" | "cue", string> = { reward: "Reward", cue: "Cue" };
       parts.push(`Phase: ${phaseLabel[s.phase]}`);
     }


### PR DESCRIPTION
## Summary

Closes #80. The inverse of #78 (now merged): there the start-summary modal was fixed to **hide** hardware fields that don't apply to the selected paradigm/mode — but `handleStart` still **sent** those values to the firmware, so the operator's confirmation could disagree with what was transmitted.

Two cases, both now gated to match the summary:

1. **Laser phase (694/695)** — was sent whenever `phase` was set, even with laser `mode === "independent"` (the summary hides `Phase:` there). Now suppressed in independent mode.
2. **Cue/pump lever-filter (378/388/478/488)** — was sent whenever the filter was not `"none"`, with no paradigm gate, even in pavlovian/omission runs where the summary hides it. Now gated on press-contingent.

## Approach

Extract two shared **type-guard predicates** into `hardwareSummary.ts` and derive **both** the summary display and the send path from them, so the sent set can never drift from the shown set:

- `leverFilterActive(leverFilter, pressContingent)` — carries the `pressContingent` gate.
- `laserPhaseActive(isPav, mode, phase)` — carries the `isPav` + non-independent gate.

Each predicate encodes its paradigm precondition internally. The summary's display output is unchanged (behavior-preserving refactor); only the send path is tightened. Send-set is now a strict subset of shown-set in every paradigm/mode combination. `tsc -b` passes; no test framework in this repo by policy.

## Notes

- Supersedes the auto-closed #81 (its base `fix/78` branch was deleted on #79's merge, which closed the PR; this is the same `fix/80` branch retargeted to `main`).
- Scope limited to `SessionStartModal.handleStart`; follow-ups filed: #82 (preset-apply paths emit ungated) and reacher#29 (firmware shadow-filter reset gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)