### PR TITLE
fix(frontend): gate preset-apply laser phase / lever-filter sends (#82)

### DIFF
--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -21,7 +21,8 @@ import { MicroscopeControl } from "../hardware/MicroscopeControl";
 import { SLMControl } from "../hardware/SLMControl";
 import { usePinOverridesHydration } from "../hardware/usePinOverridesHydration";
 import { useTutorialStore } from "../../store/useTutorialStore";
-import type { CommandSpec } from "../../types";
+import { laserPhaseActive } from "../monitor/hardwareSummary";
+import type { CommandSpec, LaserUiState } from "../../types";
 
 /* ── Default baselines for dirty-state detection ─────────────────── */
 
@@ -90,6 +91,7 @@ export function ConfigurationPanel() {
   const baselineRef = useRef<Baseline>(defaultBaseline());
 
   const paradigm = session?.paradigm?.toLowerCase();
+  const isPav = paradigm === "pavlovian";
 
   // Fetch commands for hardware section
   useEffect(() => {
@@ -229,7 +231,7 @@ export function ConfigurationPanel() {
       }
 
       // 2b. Send laser mode command if preset specifies a mode
-      const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
+      const laserState = preset.hardware.laser as LaserUiState | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
         if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
@@ -239,7 +241,7 @@ export function ConfigurationPanel() {
       }
 
       // 2c. Send laser phase command if Pavlovian preset specifies a phase
-      if (laserState?.phase) {
+      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
       }
 
@@ -315,7 +317,7 @@ export function ConfigurationPanel() {
       }
 
       // Send laser mode command if preset specifies a mode
-      const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
+      const laserState = preset.hardware.laser as LaserUiState | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
         if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
@@ -325,7 +327,7 @@ export function ConfigurationPanel() {
       }
 
       // Send laser phase command if preset specifies a phase
-      if (laserState?.phase) {
+      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
       }
     }

--- a/web/src/components/program/ProgramPanel.tsx
+++ b/web/src/components/program/ProgramPanel.tsx
@@ -10,6 +10,8 @@ import type { SessionPreset } from "./presets";
 import { ConfirmDialog } from "../layout/ConfirmDialog";
 import { useUserPresetStore } from "../../store/useUserPresetStore";
 import { getClientForSession } from "../../api/sessionClient";
+import { leverFilterActive, laserPhaseActive } from "../monitor/hardwareSummary";
+import type { LaserUiState } from "../../types";
 
 export function ProgramPanel() {
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
@@ -36,6 +38,8 @@ export function ProgramPanel() {
   const [updateConfirm, setUpdateConfirm] = useState<string | null>(null);
 
   const paradigm = session?.paradigm?.toLowerCase();
+  const isPav = paradigm === "pavlovian";
+  const pressContingent = !isPav && paradigm !== "omission";
 
   // Session presets filtered by paradigm
   const filteredSessionPresets = useMemo(() => {
@@ -131,6 +135,7 @@ export function ProgramPanel() {
             if (state[paramKey] !== undefined) {
               let value = state[paramKey];
               if (paramKey === "leverFilter") {
+                if (!leverFilterActive(state[paramKey] as "none" | "rh" | "lh" | undefined, pressContingent)) continue;
                 value = value === "rh" ? 1 : value === "lh" ? 2 : 0;
               }
               await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,code, value as number);
@@ -147,7 +152,7 @@ export function ProgramPanel() {
       }
 
       // 2b. Send laser mode command if preset specifies a mode
-      const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
+      const laserState = preset.hardware.laser as LaserUiState | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
         if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
@@ -157,7 +162,7 @@ export function ProgramPanel() {
       }
 
       // 2c. Send laser phase command if Pavlovian preset specifies a phase
-      if (laserState?.phase) {
+      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
       }
 
@@ -221,6 +226,7 @@ export function ProgramPanel() {
             if (state[paramKey] !== undefined) {
               let value = state[paramKey];
               if (paramKey === "leverFilter") {
+                if (!leverFilterActive(state[paramKey] as "none" | "rh" | "lh" | undefined, pressContingent)) continue;
                 value = value === "rh" ? 1 : value === "lh" ? 2 : 0;
               }
               await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,code, value as number);
@@ -230,7 +236,7 @@ export function ProgramPanel() {
       }
 
       // Send laser mode command if preset specifies a mode
-      const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
+      const laserState = preset.hardware.laser as LaserUiState | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
         if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
@@ -240,7 +246,7 @@ export function ProgramPanel() {
       }
 
       // Send laser phase command if preset specifies a phase
-      if (laserState?.phase) {
+      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
       }
     }


### PR DESCRIPTION
## Summary
- Wraps all 6 ungated firmware-emit sites in `ConfigurationPanel` and `ProgramPanel` with the `laserPhaseActive` / `leverFilterActive` predicates from `hardwareSummary.ts`, restoring the invariant introduced in #80 / PR #81.
- Tightens `laserState` declaration to `LaserUiState | undefined` at 4 sites (removes wider `keyof LASER_MODE_COMMANDS` intermediate cast and eliminates the `"lh_lever"` type-soundness gap flagged in review).
- Derives `isPav` / `pressContingent` matching `SessionStartModal.tsx:41,44` exactly.

## Closes
Closes #82

## Sites fixed
| File | Function | Gate |
|------|----------|------|
| `ConfigurationPanel.tsx` | `applySessionPreset` | `laserPhaseActive` |
| `ConfigurationPanel.tsx` | `applyDevicePreset` | `laserPhaseActive` |
| `ProgramPanel.tsx` | `applySessionPreset` | `leverFilterActive` |
| `ProgramPanel.tsx` | `applySessionPreset` | `laserPhaseActive` |
| `ProgramPanel.tsx` | `applyDevicePreset` | `leverFilterActive` |
| `ProgramPanel.tsx` | `applyDevicePreset` | `laserPhaseActive` |

## Follow-up noted (out of scope)
`ConfigurationPanel`'s param loop sends `leverFilter` as a raw string cast to `number` (NaN to firmware) — pre-existing issue unrelated to this PR.

## Test plan
- [ ] `npm run build` passes (tsc + vite) ✅
- [ ] Apply a session preset with a laser phase set while the paradigm is **not** Pavlovian — confirm no 694/695 commands sent
- [ ] Apply a preset carrying a leverFilter for a Pavlovian or omission paradigm — confirm no 378/388/478/488 sent
- [ ] Apply a Pavlovian preset with a non-independent laser mode + phase set — confirm 694/695 **are** sent (positive case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)