### PR TITLE
fix(frontend): exclude lh_lever from spurious cmd 681 pre-send; add to mode union

### DIFF
--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -232,7 +232,7 @@ export function ConfigurationPanel() {
       const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
+        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
           await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
         }
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
@@ -318,7 +318,7 @@ export function ConfigurationPanel() {
       const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
+        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
           await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
         }
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);

--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -169,7 +169,7 @@ export function SessionStartModal() {
       const laserState = hw.laser;
       if (laserState?.mode) {
         // For trial-paired modes, send contingent (681) first, then filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent") {
+        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
           await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
         }
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode as keyof typeof LASER_MODE_COMMANDS]);

--- a/web/src/components/monitor/hardwareSummary.ts
+++ b/web/src/components/monitor/hardwareSummary.ts
@@ -97,7 +97,7 @@ function laserParts(s: LaserUiState, ctx: SummaryContext): string[] {
   if (ctx.isPav) {
     // Pavlovian: `mode` is authoritative (independent vs. trial-paired CS filter) + phase.
     // Any non-independent mode is trial-paired; only cs_* carry a specific filter label.
-    // The default/leftover modes ("contingent", "rh_lever") must still read as Trial-Paired
+    // The default/leftover modes ("contingent", "rh_lever", "lh_lever") must still read as Trial-Paired
     // rather than silently dropping the routing token (#78).
     if (s.mode === "independent") {
       parts.push("Independent");

--- a/web/src/components/program/ProgramPanel.tsx
+++ b/web/src/components/program/ProgramPanel.tsx
@@ -150,7 +150,7 @@ export function ProgramPanel() {
       const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
+        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
           await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
         }
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
@@ -233,7 +233,7 @@ export function ProgramPanel() {
       const laserState = preset.hardware.laser as { mode?: keyof typeof LASER_MODE_COMMANDS; phase?: "reward" | "cue" } | undefined;
       if (laserState?.mode) {
         // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever") {
+        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
           await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
         }
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -49,7 +49,7 @@ export interface PumpUiState extends DeviceArmState {
 export interface LaserUiState extends DeviceArmState {
   frequency: number;
   duration: number;
-  mode: "contingent" | "independent" | "rh_lever" | "cs_plus" | "cs_minus" | "cs_both";
+  mode: "contingent" | "independent" | "rh_lever" | "lh_lever" | "cs_plus" | "cs_minus" | "cs_both";
   phase?: "reward" | "cue";  // Pavlovian only — which trial phase triggers laser
   contingency: "any" | "rh" | "lh" | "independent";  // operant lever routing (#67)
   onsetDelay: number;  // ms from trigger to laser onset (#67/#69)


### PR DESCRIPTION
Closes #87

## Summary

- **Spurious cmd 681:** The guard that gates `LASER_MODE_CONTINGENT` (681) before a lever-mode command excluded `"rh_lever"` but not `"lh_lever"` in `ProgramPanel` and `ConfigurationPanel`. `SessionStartModal` excluded neither lever mode. Selecting `lh_lever` sent 681 → 685, where only 685 should fire.
- **Dead type guard:** `LaserUiState.mode` union was missing `"lh_lever"`, making the `SessionStartModal` guard a TS2367 dead comparison — the type could never hold that value. Added `"lh_lever"` to the union so it matches `LASER_MODE_COMMANDS` (which already had `lh_lever: 685`).

## Changes

| File | Change |
|---|---|
| `web/src/types/index.ts` | Added `"lh_lever"` to `LaserUiState.mode` union |
| `web/src/components/program/ProgramPanel.tsx` (2 sites) | Added `&& laserState.mode !== "lh_lever"` to 681 guard |
| `web/src/components/configuration/ConfigurationPanel.tsx` (2 sites) | Same addition |
| `web/src/components/monitor/SessionStartModal.tsx` (1 site) | Added `&& laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever"` (this path uses typed `LaserUiState`, not the cast form) |
| `web/src/components/monitor/hardwareSummary.ts` | Updated stale comment to include `"lh_lever"` |

After this fix the exclusion set at all 5 sites is consistent: `independent, contingent, rh_lever, lh_lever` — the guard passes (sends 681) only for `cs_plus`, `cs_minus`, `cs_both`, which are the Pavlovian CS-filter modes that legitimately require the contingent preamble.

## Advisory

`cli/app.py` laser mode map is missing `rh_lever: 684` and `lh_lever: 685` — pre-existing gap, separate ticket.

## References
- Closes labrynth #87
- Part of reacher #29 (firmware lever-filter shadow fix; bug #3 is frontend)
- Follow-up to labrynth #80 / PR #81

## Test plan

- [ ] Select `lh_lever` laser mode via ProgramPanel preset apply — verify only cmd 685 is sent (no preceding 681)
- [ ] Select `lh_lever` via ConfigurationPanel preset apply — same verification
- [ ] Start session with `lh_lever` mode via SessionStartModal — same verification
- [ ] Select `cs_plus`, `cs_minus`, `cs_both` — verify cmd 681 still precedes the mode command
- [ ] Select `independent`, `contingent`, `rh_lever` — verify no cmd 681 sent
- [ ] TypeScript build clean: `cd web && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)