### PR TITLE
fix(frontend): cue control paradigm guards + contingency init (#90, #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.0.1-alpha.3] - 2026-06-25
+
+_Bug fixes: cue-control paradigm guards and contingency filter initialization._
+
+### Fixed
+- Frontend: cue frequency and duration fields in `CueControl` are now hidden for Pavlovian
+  sessions — paradigm-level controls (CS+ freq 210, CS- freq 211, cue duration 213) are
+  canonical in `PavlovianSettings`; device-level fields (371/381 freq, 372/382 dur) are
+  suppressed via `showFreqDur = paradigm !== "pavlovian"` guard
+  ([#90](https://github.com/Otis-Lab-MUSC/labrynth/issues/90))
+- Frontend: `SessionStartModal` now unconditionally sends the lever-filter command
+  (378 CUE1 / 388 CUE2) at every session start — previously only sent when
+  `leverFilterActive()` returned true (rh or lh), leaving firmware with stale
+  `DeviceType` from prior sessions; now explicitly sends 0=any, 1=rh, 2=lh to reset
+  firmware state on each start
+  ([#91](https://github.com/Otis-Lab-MUSC/labrynth/issues/91))
+
+---
+
 ## [3.0.1-alpha.2] - 2026-06-25
 
 _Re-release of v3.0.1-alpha.1 (CI builds failed on that tag due to misaligned version stamps). All three fixes below were present in alpha.1 code but were never delivered to users._

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build orchestrator, React frontend, and terminal CLI for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.2-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.3-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
 [![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labrynth"
-version = "3.0.1-alpha.2"
+version = "3.0.1-alpha.3"
 description = "Labrynth application shell — build orchestrator and frontend"
 requires-python = ">=3.10"
 dependencies = [

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 **Browser-based experiment control interface for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.2-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.3-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
 [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labrynth-frontend",
   "private": true,
-  "version": "3.0.1-alpha.2",
+  "version": "3.0.1-alpha.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -14,7 +14,7 @@ export class DemoMachineApiClient extends MachineApiClient {
 
   // --- Health ---
   probeHealth = async () =>
-    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.2", active_sessions: 0 });
+    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.3", active_sessions: 0 });
 
   // --- Sessions ---
   listSessions = () => mock.listSessions() as ReturnType<MachineApiClient["listSessions"]>;

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -165,7 +165,7 @@ export const uploadFirmware = async (id: string, paradigm: string, board: string
     board,
     firmware_info: {
       sketch: paradigm,
-      version: "3.0.1-alpha.2",
+      version: "3.0.1-alpha.3",
       baud_rate: 115200,
       desc: `Demo ${paradigm.toUpperCase()} firmware`,
     },

--- a/web/src/components/hardware/CueControl.tsx
+++ b/web/src/components/hardware/CueControl.tsx
@@ -27,6 +27,8 @@ export function CueControl({ sessionId, label, prefix, paradigm }: Props) {
   const { armed, frequency, duration } = cue;
   const codes = CODES[prefix];
   const send = (code: number, value?: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code, value);
+  // Pavlovian freq/duration are owned by PavlovianSettings (commands 210/211/213); hide here to avoid duplicates.
+  const showFreqDur = paradigm !== "pavlovian";
 
   return (
     <div className="card">
@@ -45,24 +47,28 @@ export function CueControl({ sessionId, label, prefix, paradigm }: Props) {
         >Disarm</button>
         <button onClick={() => send(codes.test)} className="btn-sm bg-yellow-600 text-white">Test</button>
       </div>
-      <div className="flex items-center gap-2">
-        <label className="text-sm text-theme-text/60">Freq (Hz):</label>
-        <input type="number" value={frequency} min={1} max={65535}
-          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], frequency: +e.target.value } }))}
-          className="w-24 input-base" />
-        <button onClick={() => send(codes.freq, frequency)}
-          disabled={frequency < 1 || frequency > 65535}
-          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
-      </div>
-      <div className="flex items-center gap-2">
-        <label className="text-sm text-theme-text/60">Dur (ms):</label>
-        <input type="number" value={duration} min={1} max={600000}
-          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], duration: +e.target.value } }))}
-          className="w-24 input-base" />
-        <button onClick={() => send(codes.dur, duration)}
-          disabled={duration < 1 || duration > 600000}
-          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
-      </div>
+      {showFreqDur && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-theme-text/60">Freq (Hz):</label>
+          <input type="number" value={frequency} min={1} max={65535}
+            onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], frequency: +e.target.value } }))}
+            className="w-24 input-base" />
+          <button onClick={() => send(codes.freq, frequency)}
+            disabled={frequency < 1 || frequency > 65535}
+            className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+        </div>
+      )}
+      {showFreqDur && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-theme-text/60">Dur (ms):</label>
+          <input type="number" value={duration} min={1} max={600000}
+            onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], duration: +e.target.value } }))}
+            className="w-24 input-base" />
+          <button onClick={() => send(codes.dur, duration)}
+            disabled={duration < 1 || duration > 600000}
+            className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+        </div>
+      )}
       <ContingencySection sessionId={sessionId} deviceKey={storeKey} paradigm={paradigm} />
     </div>
   );

--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -7,7 +7,7 @@ import { getClientForSession } from "../../api/sessionClient";
 import { PRESET_COMMAND_MAP, LASER_MODE_COMMANDS, PAV_LASER_PHASE_COMMANDS } from "../program/devicePresets";
 import { ParadigmFlowDiagram } from "./ParadigmFlowDiagram";
 import { ValidationWarningPanel } from "./ValidationWarningPanel";
-import { DEVICE_LABELS, formatDeviceParams, leverFilterActive, laserPhaseActive } from "./hardwareSummary";
+import { DEVICE_LABELS, formatDeviceParams, laserPhaseActive } from "./hardwareSummary";
 import type { ValidationResult } from "../../api/client";
 
 // Shared with PavlovianSettings so the start-summary labels every param the
@@ -155,8 +155,10 @@ export function SessionStartModal() {
           }
           // leverFilter and delay are nested at state.contingency.* — flat lookup above skips them.
           const contingency = (state as { contingency?: { leverFilter?: "none" | "rh" | "lh"; delay?: number } }).contingency;
-          if (leverFilterActive(contingency?.leverFilter, pressContingent) && mapping.params.leverFilter !== undefined) {
-            const numVal = contingency.leverFilter === "rh" ? 1 : 2;
+          // Always send filter (including 0=any) so firmware is explicitly reset at each session start,
+          // preventing stale RH/LH filters from a prior session from persisting (#91).
+          if (pressContingent && contingency?.leverFilter !== undefined && mapping.params.leverFilter !== undefined) {
+            const numVal = contingency.leverFilter === "rh" ? 1 : contingency.leverFilter === "lh" ? 2 : 0;
             await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, mapping.params.leverFilter, numVal);
           }
           if (contingency?.delay && contingency.delay > 0 && mapping.params.delay !== undefined) {


### PR DESCRIPTION
## Summary

- **#90** — Hide device-level cue `Freq`/`Dur` fields in `CueControl` for Pavlovian sessions. `PavlovianSettings` owns CS+/CS- frequency (210/211) and cue duration (213); both sets of controls were showing simultaneously with no indication of which took precedence.
- **#91** — Fix session start to always send the leverFilter command (378/388) for armed press-contingent devices, including value 0 (`DeviceType::NONE` = any lever) when the filter is at the default "none" setting. Previously, the `leverFilterActive()` guard skipped the send for "none", leaving firmware with stale RH/LH filters from prior sessions — causing "only one lever yielded reward" when left at defaults.

## Changes

| File | Change |
|---|---|
| `web/src/components/hardware/CueControl.tsx` | Add `showFreqDur = paradigm !== "pavlovian"` guard; wrap Freq/Dur rows conditionally |
| `web/src/components/monitor/SessionStartModal.tsx` | Replace `leverFilterActive()` gate with `pressContingent && leverFilter !== undefined`; encode "none"→0, "rh"→1, "lh"→2; remove now-unused `leverFilterActive` import |

Follows the established pattern in `ContingencySection.tsx:33` (`showLevers = paradigm !== "pavlovian" && paradigm !== "omission"`).

## Out of scope (noted for follow-up)

- ProgramPanel.tsx's preset-apply path has the same `leverFilterActive` pattern, but preset data stores contingency as a nested object (`state.contingency.leverFilter`) while ProgramPanel looks up the flat key `state["leverFilter"]` — making the leverFilter send path unreachable regardless. Properly fixing preset-apply contingency dispatch requires addressing the data-shape mismatch separately.
- The "secondary device (CUE 2) not firing when both set to RH" failure mode may have a firmware component on the serial→firmware path for command 388, as noted in #91.

## Test plan

- [ ] **#90**: Pavlovian session → Session Configuration → Cue 1 and Cue 2 cards show no Freq/Dur fields; switch to FR → Freq/Dur reappear
- [ ] **#91 (default)**: Start a fresh session with a cue device armed at default "Any" contingency; verify serial log shows `378=0` (and `388=0` if CUE 2 armed) at session start
- [ ] **#91 (stale-filter)**: Session 1: set CUE 1 to "RH"; end session. Session 2: leave CUE 1 at default "Any"; verify serial log shows `378=0` and LH presses now trigger the cue
- [ ] Non-Pavlovian sessions (FR, VI, PR): Cue Freq/Dur fields remain visible; contingency controls unchanged

Closes #90
Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)