### PR TITLE
fix(frontend): FR paradigm device config — PUMP 2 activation, CUE 2 delay, contingency labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.0.1-alpha.3] - 2026-06-25
+
+_Bug fixes: cue-control paradigm guards and contingency filter initialization._
+
+### Fixed
+- Frontend: cue frequency and duration fields in `CueControl` are now hidden for Pavlovian
+  sessions — paradigm-level controls (CS+ freq 210, CS- freq 211, cue duration 213) are
+  canonical in `PavlovianSettings`; device-level fields (371/381 freq, 372/382 dur) are
+  suppressed via `showFreqDur = paradigm !== "pavlovian"` guard
+  ([#90](https://github.com/Otis-Lab-MUSC/labrynth/issues/90))
+- Frontend: `SessionStartModal` now unconditionally sends the lever-filter command
+  (378 CUE1 / 388 CUE2) at every session start — previously only sent when
+  `leverFilterActive()` returned true (rh or lh), leaving firmware with stale
+  `DeviceType` from prior sessions; now explicitly sends 0=any, 1=rh, 2=lh to reset
+  firmware state on each start
+  ([#91](https://github.com/Otis-Lab-MUSC/labrynth/issues/91))
+
+---
+
 ## [3.0.1-alpha.2] - 2026-06-25
 
 _Re-release of v3.0.1-alpha.1 (CI builds failed on that tag due to misaligned version stamps). All three fixes below were present in alpha.1 code but were never delivered to users._

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build orchestrator, React frontend, and terminal CLI for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.2-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.3-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
 [![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labrynth"
-version = "3.0.1-alpha.2"
+version = "3.0.1-alpha.3"
 description = "Labrynth application shell — build orchestrator and frontend"
 requires-python = ">=3.10"
 dependencies = [

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 **Browser-based experiment control interface for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.2-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.3-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
 [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labrynth-frontend",
   "private": true,
-  "version": "3.0.1-alpha.2",
+  "version": "3.0.1-alpha.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -14,7 +14,7 @@ export class DemoMachineApiClient extends MachineApiClient {
 
   // --- Health ---
   probeHealth = async () =>
-    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.2", active_sessions: 0 });
+    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.3", active_sessions: 0 });
 
   // --- Sessions ---
   listSessions = () => mock.listSessions() as ReturnType<MachineApiClient["listSessions"]>;

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -165,7 +165,7 @@ export const uploadFirmware = async (id: string, paradigm: string, board: string
     board,
     firmware_info: {
       sketch: paradigm,
-      version: "3.0.1-alpha.2",
+      version: "3.0.1-alpha.3",
       baud_rate: 115200,
       desc: `Demo ${paradigm.toUpperCase()} firmware`,
     },

--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -230,6 +230,19 @@ export function ConfigurationPanel() {
         }
       }
 
+      // Send SET_ACTIVE_PUMP (cmd 221) so firmware reward chain uses the correct pump.
+      // Operant paradigms only (cmd 221 is not registered for Pavlovian).
+      if (!isPav) {
+        let pump2Active = false;
+        if ("secondaryPump" in preset.hardware) {
+          const spState = preset.hardware.secondaryPump as { armed: boolean } | undefined;
+          pump2Active = "secondaryPump" in armOverrides
+            ? armOverrides["secondaryPump"]
+            : (spState?.armed ?? false);
+        }
+        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, 221, pump2Active ? 1 : 0);
+      }
+
       // 2b. Send laser mode command if preset specifies a mode
       const laserState = preset.hardware.laser as LaserUiState | undefined;
       if (laserState?.mode) {
@@ -314,6 +327,13 @@ export function ConfigurationPanel() {
             }
           }
         }
+      }
+
+      // Send SET_ACTIVE_PUMP (cmd 221) if preset addresses secondaryPump.
+      // Partial-takeover: if secondaryPump is absent from the preset, leave active-pump state alone.
+      if (!isPav && "secondaryPump" in preset.hardware) {
+        const spState = preset.hardware.secondaryPump as { armed: boolean } | undefined;
+        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, 221, (spState?.armed ?? false) ? 1 : 0);
       }
 
       // Send laser mode command if preset specifies a mode

--- a/web/src/components/hardware/ContingencySection.tsx
+++ b/web/src/components/hardware/ContingencySection.tsx
@@ -19,7 +19,7 @@ const FILTER_CMD: Record<Props["deviceKey"], number> = {
 // Per-device onset delay commands (ms from trigger to device activation)
 const DELAY_CMD: Record<Props["deviceKey"], number> = {
   primaryCue:    377,
-  secondaryCue:  387,
+  secondaryCue:  387, // CUE2_SET_ONSET_DELAY — firmware handler unimplemented; UI suppresses input for secondaryCue
   primaryPump:   477,
   secondaryPump: 487,
 };
@@ -90,7 +90,7 @@ export function ContingencySection({ sessionId, deviceKey, paradigm }: Props) {
         <>
           <div className="text-xs font-medium uppercase tracking-wide text-theme-text/60">Contingent on</div>
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-xs text-theme-text/60">Trigger on:</span>
+            <span className="text-xs text-theme-text/60">Lever filter:</span>
           {(["none", "rh", "lh"] as const).map((opt) => (
             <button
               key={opt}
@@ -101,24 +101,28 @@ export function ContingencySection({ sessionId, deviceKey, paradigm }: Props) {
                   : "bg-theme-text/10 text-theme-text/70 hover:bg-theme-text/20"
               }`}
             >
-              {opt === "none" ? "Any" : opt.toUpperCase()}
+              {opt === "none" ? "Any lever" : opt === "rh" ? "RH lever" : "LH lever"}
             </button>
           ))}
           </div>
         </>
       )}
-      <div className="flex items-center gap-2">
-        <label className="text-xs text-theme-text/60">Delay (ms):</label>
-        <input
-          type="number"
-          min={0}
-          max={600000}
-          value={contingency.delay}
-          onChange={(e) => setDelay(+e.target.value)}
-          className="w-24 input-base"
-          title="Onset delay from trigger to device activation"
-        />
-      </div>
+      {deviceKey === "secondaryCue" ? (
+        <p className="text-xs text-theme-text/50 italic">Shares onset delay with Cue 1</p>
+      ) : (
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-theme-text/60">Delay (ms):</label>
+          <input
+            type="number"
+            min={0}
+            max={600000}
+            value={contingency.delay}
+            onChange={(e) => setDelay(+e.target.value)}
+            className="w-24 input-base"
+            title="Onset delay from trigger to device activation"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/hardware/CueControl.tsx
+++ b/web/src/components/hardware/CueControl.tsx
@@ -27,6 +27,8 @@ export function CueControl({ sessionId, label, prefix, paradigm }: Props) {
   const { armed, frequency, duration } = cue;
   const codes = CODES[prefix];
   const send = (code: number, value?: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code, value);
+  // Pavlovian freq/duration are owned by PavlovianSettings (commands 210/211/213); hide here to avoid duplicates.
+  const showFreqDur = paradigm !== "pavlovian";
 
   return (
     <div className="card">
@@ -45,24 +47,28 @@ export function CueControl({ sessionId, label, prefix, paradigm }: Props) {
         >Disarm</button>
         <button onClick={() => send(codes.test)} className="btn-sm bg-yellow-600 text-white">Test</button>
       </div>
-      <div className="flex items-center gap-2">
-        <label className="text-sm text-theme-text/60">Freq (Hz):</label>
-        <input type="number" value={frequency} min={1} max={65535}
-          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], frequency: +e.target.value } }))}
-          className="w-24 input-base" />
-        <button onClick={() => send(codes.freq, frequency)}
-          disabled={frequency < 1 || frequency > 65535}
-          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
-      </div>
-      <div className="flex items-center gap-2">
-        <label className="text-sm text-theme-text/60">Dur (ms):</label>
-        <input type="number" value={duration} min={1} max={600000}
-          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], duration: +e.target.value } }))}
-          className="w-24 input-base" />
-        <button onClick={() => send(codes.dur, duration)}
-          disabled={duration < 1 || duration > 600000}
-          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
-      </div>
+      {showFreqDur && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-theme-text/60">Freq (Hz):</label>
+          <input type="number" value={frequency} min={1} max={65535}
+            onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], frequency: +e.target.value } }))}
+            className="w-24 input-base" />
+          <button onClick={() => send(codes.freq, frequency)}
+            disabled={frequency < 1 || frequency > 65535}
+            className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+        </div>
+      )}
+      {showFreqDur && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-theme-text/60">Dur (ms):</label>
+          <input type="number" value={duration} min={1} max={600000}
+            onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], duration: +e.target.value } }))}
+            className="w-24 input-base" />
+          <button onClick={() => send(codes.dur, duration)}
+            disabled={duration < 1 || duration > 600000}
+            className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+        </div>
+      )}
       <ContingencySection sessionId={sessionId} deviceKey={storeKey} paradigm={paradigm} />
     </div>
   );

--- a/web/src/components/hardware/PumpControl.tsx
+++ b/web/src/components/hardware/PumpControl.tsx
@@ -17,12 +17,18 @@ const CODES = {
 
 const STORE_KEY = { "": "primaryPump", "2": "secondaryPump" } as const;
 
+const SET_ACTIVE_PUMP = 221;
 const MIN_DURATION = 1;
 const MAX_DURATION = 600000;
 
 export function PumpControl({ sessionId, label, prefix, paradigm }: Props) {
   const storeKey = STORE_KEY[prefix];
+  const siblingPrefix = (prefix === "" ? "2" : "") as "" | "2";
+  const siblingKey = STORE_KEY[siblingPrefix];
+
+  // All hooks unconditionally before any early return (Rules of Hooks)
   const pump = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi[storeKey]);
+  const siblingPump = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi[siblingKey]);
   const updateHardwareUi = useSessionStore((s) => s.updateHardwareUi);
 
   if (!pump) return null;
@@ -34,19 +40,51 @@ export function PumpControl({ sessionId, label, prefix, paradigm }: Props) {
   const update = (patch: Partial<typeof pump>) =>
     updateHardwareUi(sessionId, (prev) => ({ [storeKey]: { ...prev[storeKey], ...patch } }));
 
+  const isOperant = paradigm !== undefined && paradigm !== "pavlovian";
+
+  const handleArm = () => {
+    if (isOperant) {
+      const sibling = useSessionStore.getState().sessions.get(sessionId)?.hardwareUi[siblingKey];
+      if (sibling?.armed) {
+        send(CODES[siblingPrefix].disarm);
+        updateHardwareUi(sessionId, (prev) => ({
+          [siblingKey]: { ...(prev[siblingKey] as object), armed: false },
+        }));
+      }
+      send(codes.arm);
+      send(SET_ACTIVE_PUMP, prefix === "2" ? 1 : 0);
+    } else {
+      send(codes.arm);
+    }
+    update({ armed: true });
+  };
+
+  const handleDisarm = () => {
+    send(codes.disarm);
+    if (isOperant && prefix === "2") {
+      send(SET_ACTIVE_PUMP, 0);
+    }
+    update({ armed: false });
+  };
+
   return (
     <div className="card">
-      <h3 className="font-medium text-theme-text">
-        Pump {label}
+      <h3 className="font-medium text-theme-text flex items-center gap-2 flex-wrap">
+        <span>Pump {label}</span>
         <PinField sessionId={sessionId} component={prefix === "2" ? "pump2" : "pump"} />
+        {isOperant && armed && !siblingPump?.armed && (
+          <span className="rounded px-1.5 py-0.5 text-xs font-mono bg-green-600/20 text-green-400 uppercase tracking-wide">
+            Active
+          </span>
+        )}
       </h3>
       <div className="flex flex-wrap gap-2">
         <button
-          onClick={() => { send(codes.arm); update({ armed: true }); }}
+          onClick={handleArm}
           className={`btn-sm ${armed ? "btn-toggle-green-on" : "btn-toggle-green-off"}`}
         >Arm</button>
         <button
-          onClick={() => { send(codes.disarm); update({ armed: false }); }}
+          onClick={handleDisarm}
           className={`btn-sm ${!armed ? "btn-toggle-red-on" : "btn-toggle-red-off"}`}
         >Disarm</button>
         <button onClick={() => send(codes.test)} className="btn-sm bg-yellow-600 text-white">Test</button>

--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -7,7 +7,7 @@ import { getClientForSession } from "../../api/sessionClient";
 import { PRESET_COMMAND_MAP, LASER_MODE_COMMANDS, PAV_LASER_PHASE_COMMANDS } from "../program/devicePresets";
 import { ParadigmFlowDiagram } from "./ParadigmFlowDiagram";
 import { ValidationWarningPanel } from "./ValidationWarningPanel";
-import { DEVICE_LABELS, formatDeviceParams, leverFilterActive, laserPhaseActive } from "./hardwareSummary";
+import { DEVICE_LABELS, formatDeviceParams, laserPhaseActive } from "./hardwareSummary";
 import type { ValidationResult } from "../../api/client";
 
 // Shared with PavlovianSettings so the start-summary labels every param the
@@ -155,8 +155,10 @@ export function SessionStartModal() {
           }
           // leverFilter and delay are nested at state.contingency.* — flat lookup above skips them.
           const contingency = (state as { contingency?: { leverFilter?: "none" | "rh" | "lh"; delay?: number } }).contingency;
-          if (leverFilterActive(contingency?.leverFilter, pressContingent) && mapping.params.leverFilter !== undefined) {
-            const numVal = contingency.leverFilter === "rh" ? 1 : 2;
+          // Always send filter (including 0=any) so firmware is explicitly reset at each session start,
+          // preventing stale RH/LH filters from a prior session from persisting (#91).
+          if (pressContingent && contingency?.leverFilter !== undefined && mapping.params.leverFilter !== undefined) {
+            const numVal = contingency.leverFilter === "rh" ? 1 : contingency.leverFilter === "lh" ? 2 : 0;
             await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, mapping.params.leverFilter, numVal);
           }
           if (contingency?.delay && contingency.delay > 0 && mapping.params.delay !== undefined) {

--- a/web/src/components/program/devicePresets.ts
+++ b/web/src/components/program/devicePresets.ts
@@ -36,7 +36,7 @@ export const PRESET_COMMAND_MAP: Record<string, { arm: number; disarm: number; p
   rhLever:       { arm: 1001, disarm: 1000, params: { timeout: 1074 } },
   lhLever:       { arm: 1301, disarm: 1300, params: { timeout: 1374 } },
   primaryCue:    { arm: 301,  disarm: 300,  params: { frequency: 371, duration: 372, leverFilter: 378, delay: 377 } },
-  secondaryCue:  { arm: 311,  disarm: 310,  params: { frequency: 381, duration: 382, leverFilter: 388, delay: 387 } },
+  secondaryCue:  { arm: 311,  disarm: 310,  params: { frequency: 381, duration: 382, leverFilter: 388 } },
   primaryPump:   { arm: 401,  disarm: 400,  params: { duration: 472,  leverFilter: 478, delay: 477 } },
   secondaryPump: { arm: 411,  disarm: 410,  params: { duration: 482,  leverFilter: 488, delay: 487 } },
   laser:         { arm: 601,  disarm: 600,  params: { frequency: 671, duration: 672, delay: 673 } },


### PR DESCRIPTION
Closes #93

## Summary

Three confirmed bugs in the FR paradigm hardware configuration UI, persistent across at least two prior issues:

- **PUMP 2 never fired** — `PumpControl` sent `PUMP2_ARM` (411) but never `SET_ACTIVE_PUMP` (221). The FR firmware reward chain uses `activePump` (default: pump 1); without cmd 221, PUMP 2 was permanently bypassed regardless of how it was configured. Fix: arm/disarm in operant paradigms now sends 221, enforces mutual exclusion (arming one pump auto-disarms the other), and shows an "Active" badge on the pump currently in the reward chain.

- **CUE 2 onset delay was a no-op** — The firmware `CUE2_SET_ONSET_DELAY` case (cmd 387) is explicitly empty; both CUE and CUE2 share `CUE_ONSET_DELAY`. The delay input sent an ignored command. Fix: delay input is suppressed for CUE 2 with an explanatory note; cmd 387 removed from the preset command map.

- **Misleading "Trigger on" label** — "Trigger on: Any/RH/LH" implied devices independently fire on lever press. The actual firmware semantics: the device activates as part of the reward chain when the reward was earned by that lever. Fix: renamed to "Lever filter:" with options "Any lever / RH lever / LH lever".

## Changes

| File | Change |
|---|---|
| `PumpControl.tsx` | `SET_ACTIVE_PUMP` (221) on arm/disarm; mutual exclusion; "Active" badge |
| `ContingencySection.tsx` | "Lever filter:" label; clarified option names; CUE 2 delay suppressed |
| `ConfigurationPanel.tsx` | cmd 221 injected after preset apply in both `applySessionPreset` and `applyDevicePreset` |
| `devicePresets.ts` | Removed dead `delay: 387` from `secondaryCue` params |

## Test plan

- [ ] Arm Pump 2 in an FR session → network tab shows 400 (pump1 disarm), 411 (pump2 arm), 221 value=1 in order; "Active" badge appears on Pump 2
- [ ] With Pump 2 active, arm Pump 1 → Pump 2 auto-disarms, badge moves to Pump 1
- [ ] Disarm Pump 2 → 410 + 221 value=0 sent; no badge on either pump
- [ ] Cue 2 card shows "Shares onset delay with Cue 1" note, no delay input; no cmd 387 in network tab
- [ ] ContingencySection shows "Lever filter:" with "Any lever / RH lever / LH lever" buttons
- [ ] Apply SA preset → cmd 221 value=0 appears after device arm/disarm commands
- [ ] Pavlovian session: pump arm/disarm sends no cmd 221; no "Active" badge; both pumps arm independently

## Risk flags

- `unknown_unknowns`: `StartSession()` in fr.ino resets all `sourceFilter` shadows to NONE, discarding any pre-session lever-filter configuration. This is a separate firmware bug (tracked in the reacher repo); it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)