### PR TITLE
fix(session): clear stale exportState on restart/split, guard concurrent exports

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -255,7 +255,7 @@ export class MachineApiClient {
     this.request<{ frames: unknown[]; count: number }>(`/data/${id}/frames`);
   getSlmEvents = (id: string) =>
     this.request<{ slm: number[]; count: number }>(`/data/${id}/slm`);
-  exportZip = (
+  exportZip = async (
     id: string,
     body: {
       session_name?: string;
@@ -267,11 +267,19 @@ export class MachineApiClient {
       microscope_frame_rate?: number | null;
       microscope_frame_averaging?: number | null;
     },
-  ) =>
-    this.request<{ file_path: string; folder_path: string }>(`/file/${id}/export/zip`, {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
+  ) => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 60_000);
+    try {
+      return await this.request<{ file_path: string; folder_path: string }>(`/file/${id}/export/zip`, {
+        method: "POST",
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
 
   // --- Download ---
   downloadExportZip = async (id: string, filePath: string): Promise<void> => {

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -66,6 +66,7 @@ export class DemoMachineApiClient extends MachineApiClient {
       microscope_frame_rate?: number | null;
       microscope_frame_averaging?: number | null;
     },
+  // not async: mock.exportZip already returns a Promise; cast satisfies the parent signature
   ) => mock.exportZip(id, body) as ReturnType<MachineApiClient["exportZip"]>;
 
   // --- Download ---

--- a/web/src/components/layout/ServerSuspendedOverlay.tsx
+++ b/web/src/components/layout/ServerSuspendedOverlay.tsx
@@ -13,7 +13,7 @@ export function ServerSuspendedOverlay() {
   );
   const sessionIdWithData = useSessionStore((s) => {
     for (const [id, sess] of s.sessions) {
-      if ((sess.behaviorData?.length ?? 0) > 0 && !sess.exportState?.result) return id;
+      if ((sess.behaviorData?.length ?? 0) > 0 && !sess.exportState?.result && !sess.exportState?.exporting) return id;
     }
     return null;
   });

--- a/web/src/hooks/useSessionWebSockets.ts
+++ b/web/src/hooks/useSessionWebSockets.ts
@@ -34,11 +34,15 @@ const DEVICE_TO_UI_KEY: Record<string, string> = {
 export async function triggerAutoExport(sessionId: string) {
   const sess = useSessionStore.getState().sessions.get(sessionId);
   if (!sess || !sess.behaviorData.length) return;
+  if (sess.exportState?.result || sess.exportState?.exporting) return;
   const client = getClientForSession(sessionId);
   if (!client) return;
 
   const { setExportState } = useSessionStore.getState();
   const { pushLog } = useLogStore.getState();
+  // Capture the current program's start time so that if a new program starts mid-export,
+  // the resolved Promise can't clobber the new program's clean exportState.
+  const startedAt = sess.programStartTime;
   setExportState(sessionId, { exporting: true, result: null, error: null });
   try {
     const micro = sess.hardwareUi.microscope;
@@ -55,12 +59,19 @@ export async function triggerAutoExport(sessionId: string) {
     if (result?.file_path && client.isRemote) {
       try { await client.downloadExportZip(sessionId, result.file_path); } catch { /* log already surfaces remote errors */ }
     }
+    if (useSessionStore.getState().sessions.get(sessionId)?.programStartTime !== startedAt) {
+      pushLog("warn", "Export completed but session was reset mid-export — result discarded", sessionId);
+      return;
+    }
     setExportState(sessionId, { exporting: false, result: result?.file_path ?? null });
     pushLog("info", `Session data saved: ${result?.file_path}`, sessionId);
   } catch (e) {
+    if (useSessionStore.getState().sessions.get(sessionId)?.programStartTime !== startedAt) return;
     setExportState(sessionId, {
       exporting: false,
-      error: e instanceof Error ? e.message : "Auto-export failed",
+      error: e instanceof DOMException && e.name === "AbortError"
+        ? "Auto-export timed out after 60 s — retry manually"
+        : e instanceof Error ? e.message : "Auto-export failed",
     });
   }
 }
@@ -180,7 +191,7 @@ function handleMessage(msg: WSMessage) {
         useAppStore.getState().setServerSuspended(true, hard_kill_in);
       } else {
         const sess = useSessionStore.getState().sessions.get(msg.session_id);
-        if (sess?.behaviorData.length && !sess.exportState?.result) {
+        if (sess?.behaviorData.length && !sess.exportState?.result && !sess.exportState?.exporting) {
           triggerAutoExport(msg.session_id);
         }
       }
@@ -195,7 +206,7 @@ function handleMessage(msg: WSMessage) {
       const { hard_kill_in } = msg.data as { reason: string; hard_kill_in: number };
       pushLog("warn", `Session orphaned — server had no connected clients during active session. Hard kill in ~${Math.round(hard_kill_in / 60)} min.`, msg.session_id);
       const sess = useSessionStore.getState().sessions.get(msg.session_id);
-      if (sess?.behaviorData.length && !sess.exportState?.result) {
+      if (sess?.behaviorData.length && !sess.exportState?.result && !sess.exportState?.exporting) {
         triggerAutoExport(msg.session_id);
       }
       break;
@@ -318,7 +329,7 @@ export function useSessionWebSockets() {
             useAppStore.getState().setServerSuspended(true);
           } else {
             const sess = useSessionStore.getState().sessions.get(id);
-            if (sess?.behaviorData.length && !sess.exportState?.result) {
+            if (sess?.behaviorData.length && !sess.exportState?.result && !sess.exportState?.exporting) {
               triggerAutoExport(id);
             }
           }

--- a/web/src/store/useSessionStore.ts
+++ b/web/src/store/useSessionStore.ts
@@ -595,6 +595,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
           inactive: sess.cumulativeLhLeverCounts.inactive + sess.lhLeverCounts.inactive,
         },
         cumulativeElapsedTime: sess.cumulativeElapsedTime + segmentElapsedMs,
+        exportState: { exporting: false, result: null, error: null },
         programStartTime: now,
         programEndTime: null,
         pausedTime: 0,
@@ -619,6 +620,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       next.set(id, {
         ...sess,
         state: "running",
+        exportState: { exporting: false, result: null, error: null },
         behaviorData: [],
         frameData: [],
         slmData: [],


### PR DESCRIPTION
Closes #95

## Summary

- **Root cause fix:** `handleRestart` and `handleSplit` bypassed `updateState()` and left the prior program's `exportState.result` intact. On abnormal session termination (server_suspended / session_orphaned / WS give-up), all three call sites gate on `!sess.exportState?.result` — so the stale path from program 1 silently suppressed program 2's export and its data was lost.
- **Concurrent-export guard:** Added a uniform `!result || !exporting` guard inside `triggerAutoExport` itself, protecting all four call sites. Aligned pre-call guards at the three abnormal-termination sites to match.
- **Generation guard:** Captures `programStartTime` before the export await; no-ops both the resolve and catch `setExportState` writes if a new program has started mid-export, preventing program 1's late-resolving export from clobbering program 2's clean state.
- **60 s export timeout:** `AbortController + setTimeout` (ES2020-compatible) bounds a hung `exportZip` call so it rejects and the existing catch resets `exporting: false` rather than leaving the session permanently stuck.
- **Overlay gap:** `ServerSuspendedOverlay` now hides the "Export Session Data" button while an export is already in-flight.
- **UX:** Surfaces a readable timeout message and a warn-log when a mid-export reset discards a completed export result.

## Files changed

| File | Change |
|---|---|
| `web/src/store/useSessionStore.ts` | Add `exportState` reset to `handleRestart` + `handleSplit` |
| `web/src/hooks/useSessionWebSockets.ts` | Uniform guard, generation guard, call-site alignment, warn logs, AbortError message |
| `web/src/api/client.ts` | 60 s `AbortController` timeout on `exportZip` |
| `web/src/components/layout/ServerSuspendedOverlay.tsx` | Add `!exporting` to `sessionIdWithData` predicate |
| `web/src/api/demoClient.ts` | Clarifying comment on async/Promise compatibility |

## Test plan

No automated test framework in this project. Manual checklist:

- [ ] Run program A → END → confirm exactly one zip POST, log shows `Session data saved: <path>`
- [ ] Restart → run program B → END normally → confirm B exports (previously data lost)
- [ ] Restart → run program B → trigger server_suspended → confirm B exports
- [ ] Double CONTROLLER-END in one tick → confirm single export POST
- [ ] Kill remote mid-export (simulate hang) → confirm session is not stuck exporting after 60 s timeout
- [ ] Start program B immediately after program A's export resolves → confirm B's `exportState` not clobbered with A's path

## Deferred follow-ups

- `probeHealth` in `client.ts` uses `AbortSignal.timeout(5000)` (same ES2020 gap) — pre-existing, should be reconciled separately
- localStorage persistence of `exportResult` — scoped out (unverified file paths introduce a false-positive "saved" state); needs backend file-existence verification first
- `handleSplit` per-segment export trigger — backend auto-export semantics for split segments are unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)