### PR TITLE
feat: match laser contingent-on ui to cue/pump, fix pre-session timeline, add SLM SYNC laser record-keeping fields

### DIFF
--- a/cli/app.py
+++ b/cli/app.py
@@ -141,7 +141,6 @@ PARADIGM_SETTING_CODES = {
     "step": 205,
     "vi_interval": 204,
     "om_interval": 203,
-    "trace_interval": 220,
 }
 
 # Curated short labels for Pavlovian params. The param *list* is sourced
@@ -205,7 +204,7 @@ PRESETS: dict[str, dict] = {
             "lick-circuit": {"armed": False},
             "microscope": {"armed": False},
         },
-        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000, "trace_interval": 0},
+        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000},
         "limits": {"type": "Both", "time_limit": 3600, "infusion_limit": 10, "delay": 60},
     },
     "sa-mid": {
@@ -222,7 +221,7 @@ PRESETS: dict[str, dict] = {
             "lick-circuit": {"armed": False},
             "microscope": {"armed": False},
         },
-        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000, "trace_interval": 0},
+        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000},
         "limits": {"type": "Both", "time_limit": 3600, "infusion_limit": 20, "delay": 60},
     },
     "sa-low": {
@@ -239,7 +238,7 @@ PRESETS: dict[str, dict] = {
             "lick-circuit": {"armed": False},
             "microscope": {"armed": False},
         },
-        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000, "trace_interval": 0},
+        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000},
         "limits": {"type": "Both", "time_limit": 3600, "infusion_limit": 40, "delay": 60},
     },
     "sa-extinction": {
@@ -256,7 +255,7 @@ PRESETS: dict[str, dict] = {
             "lick-circuit": {"armed": False},
             "microscope": {"armed": False},
         },
-        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000, "trace_interval": 0},
+        "paradigm_settings": {"ratio": 1, "step": 1, "interval": 30000},
         "limits": {"type": "Time", "time_limit": 3600, "infusion_limit": 30, "delay": 60},
     },
 }
@@ -298,7 +297,7 @@ class SessionState:
     armed: dict = field(default_factory=dict)
     test_mode: bool = False
     paradigm_settings: dict = field(
-        default_factory=lambda: {"ratio": 1, "step": 1, "interval": 30000, "trace_interval": 0}
+        default_factory=lambda: {"ratio": 1, "step": 1, "interval": 30000}
     )
     pavlovian_params: dict = field(default_factory=dict)  # {code: value}, last-set Pavlovian params
     limit_settings: dict = field(
@@ -680,7 +679,6 @@ class ReacherCLI:
         s = self.session
         paradigm = s.paradigm if s else None
         ps = s.paradigm_settings if s else {}
-        show_trace = paradigm in ("fr", "pr", "vi")
 
         items: list[MenuItem] = []
         if paradigm in ("fr", "pr"):
@@ -699,11 +697,6 @@ class ReacherCLI:
             items.append(MenuItem("Set Omission Interval (ms)", action=lambda: self._prompt_int_input(
                 "Enter omission interval (ms):", lambda v: self._send_paradigm_setting("om_interval", v)
             ), suffix=f"({ps.get('interval', 30000)})"))
-        if show_trace:
-            items.append(MenuItem("Set Trace Interval (ms)", action=lambda: self._prompt_int_input(
-                "Enter trace interval (ms):", lambda v: self._send_paradigm_setting("trace_interval", v)
-            ), suffix=f"({ps.get('trace_interval', 0)})"))
-
         if not items:
             hint = "Pavlovian: use Pavlovian Settings" if paradigm == "pavlovian" else "No paradigm selected"
             items.append(MenuItem(f"──── {hint} ────", is_separator=True))

--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -26,7 +26,7 @@ import type { CommandSpec, LaserUiState } from "../../types";
 
 /* ── Default baselines for dirty-state detection ─────────────────── */
 
-const DEFAULT_PARADIGM_SETTINGS = { ratio: 1, step: 1, interval: 30000, traceInterval: 0 };
+const DEFAULT_PARADIGM_SETTINGS = { ratio: 1, step: 1, interval: 30000 };
 
 interface Baseline {
   hardwareUi: string;
@@ -265,7 +265,6 @@ export function ConfigurationPanel() {
         }
       } else {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,201, preset.paradigmSettings.ratio);
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,220, preset.paradigmSettings.traceInterval);
       }
     }
 

--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -243,19 +243,31 @@ export function ConfigurationPanel() {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, 221, pump2Active ? 1 : 0);
       }
 
-      // 2b. Send laser mode command if preset specifies a mode
+      // 2b. Send laser mode/contingency command if preset specifies one.
+      // Pavlovian: `mode` (+ `phase`) is authoritative. Operant: `contingency` is authoritative —
+      // `mode` is Pavlovian-only and can be stale, so it must not drive operant dispatch (mirrors
+      // hardwareSummary.ts's laserParts() and SessionStartModal.tsx's session-start dispatch).
       const laserState = preset.hardware.laser as LaserUiState | undefined;
-      if (laserState?.mode) {
-        // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
-          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+      if (isPav) {
+        if (laserState?.mode) {
+          // Pavlovian trial-paired modes require contingent (681) before filter command
+          if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
+            await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+          }
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
         }
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
-      }
-
-      // 2c. Send laser phase command if Pavlovian preset specifies a phase
-      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        // 2c. Send laser phase command if Pavlovian preset specifies a phase
+        if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        }
+      } else if (laserState?.contingency) {
+        const contingencyCommand = {
+          any: LASER_MODE_COMMANDS.contingent,
+          rh: LASER_MODE_COMMANDS.rh_lever,
+          lh: LASER_MODE_COMMANDS.lh_lever,
+          independent: LASER_MODE_COMMANDS.independent,
+        }[laserState.contingency];
+        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, contingencyCommand);
       }
 
       // 3. Send paradigm-specific commands
@@ -335,19 +347,29 @@ export function ConfigurationPanel() {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, 221, (spState?.armed ?? false) ? 1 : 0);
       }
 
-      // Send laser mode command if preset specifies a mode
+      // Send laser mode/contingency command if preset specifies one (see applySessionPreset
+      // above for why Pavlovian uses `mode` and operant uses `contingency`).
       const laserState = preset.hardware.laser as LaserUiState | undefined;
-      if (laserState?.mode) {
-        // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
-          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+      if (isPav) {
+        if (laserState?.mode) {
+          // Pavlovian trial-paired modes require contingent (681) before filter command
+          if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
+            await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+          }
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
         }
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
-      }
-
-      // Send laser phase command if preset specifies a phase
-      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        // Send laser phase command if preset specifies a phase
+        if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        }
+      } else if (laserState?.contingency) {
+        const contingencyCommand = {
+          any: LASER_MODE_COMMANDS.contingent,
+          rh: LASER_MODE_COMMANDS.rh_lever,
+          lh: LASER_MODE_COMMANDS.lh_lever,
+          independent: LASER_MODE_COMMANDS.independent,
+        }[laserState.contingency];
+        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, contingencyCommand);
       }
     }
   };

--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -216,7 +216,7 @@ export function ConfigurationPanel() {
         }
         if (mapping.params) {
           for (const [paramKey, code] of Object.entries(mapping.params)) {
-            if (state[paramKey] !== undefined) {
+            if (state[paramKey] !== undefined && state[paramKey] !== null) {
               await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,code, state[paramKey] as number);
             }
           }
@@ -333,7 +333,7 @@ export function ConfigurationPanel() {
         }
         if (mapping.params) {
           for (const [paramKey, code] of Object.entries(mapping.params)) {
-            if (state[paramKey] !== undefined) {
+            if (state[paramKey] !== undefined && state[paramKey] !== null) {
               await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,code, state[paramKey] as number);
             }
           }

--- a/web/src/components/hardware/LaserControl.tsx
+++ b/web/src/components/hardware/LaserControl.tsx
@@ -88,20 +88,41 @@ export function LaserControl({ sessionId, paradigm }: Props) {
           )}
         </>
       ) : (
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm text-theme-text/60">Contingent on:</span>
-          {([
-            ["any", "Any", LASER_MODE_COMMANDS.contingent],
-            ["rh", "RH", LASER_MODE_COMMANDS.rh_lever],
-            ["lh", "LH", LASER_MODE_COMMANDS.lh_lever],
-            ["independent", "Independent", LASER_MODE_COMMANDS.independent],
-          ] as const).map(([val, label, cmd]) => (
-            <button
-              key={val}
-              onClick={() => { send(cmd); updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, contingency: val } })); }}
-              className={`btn-sm ${contingency === val ? "bg-purple-600" : "bg-purple-600/40"} text-white`}
-            >{label}</button>
-          ))}
+        <div className="border-t border-theme-text/10 pt-2 mt-1 space-y-2">
+          <div className="text-xs font-medium uppercase tracking-wide text-theme-text/60">Contingent on</div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs text-theme-text/60">Lever filter:</span>
+            {([
+              ["any", "Any lever", LASER_MODE_COMMANDS.contingent],
+              ["rh", "RH lever", LASER_MODE_COMMANDS.rh_lever],
+              ["lh", "LH lever", LASER_MODE_COMMANDS.lh_lever],
+              ["independent", "Independent", LASER_MODE_COMMANDS.independent],
+            ] as const).map(([val, label, cmd]) => (
+              <button
+                key={val}
+                onClick={() => { send(cmd); updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, contingency: val } })); }}
+                className={`px-2 py-0.5 rounded text-xs font-medium transition-colors ${
+                  contingency === val
+                    ? "bg-accent text-white"
+                    : "bg-theme-text/10 text-theme-text/70 hover:bg-theme-text/20"
+                }`}
+              >{label}</button>
+            ))}
+          </div>
+          {contingency === "independent" ? (
+            <p className="text-xs text-theme-text/50 italic">Independent mode free-runs continuously — no onset delay applies</p>
+          ) : (
+            <div className="flex items-center gap-2">
+              <label className="text-xs text-theme-text/60">Delay (ms):</label>
+              <input type="number" value={onsetDelay} min={0} max={delayMax}
+                onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, onsetDelay: Math.min(Math.max(0, +e.target.value), delayMax) } }))}
+                className="w-24 input-base"
+                title="Onset delay from lever press onset to laser activation" />
+              <button onClick={() => send(673, onsetDelay)}
+                disabled={onsetDelay < 0 || onsetDelay > delayMax}
+                className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+            </div>
+          )}
         </div>
       )}
       <div className="flex items-center gap-2">
@@ -122,15 +143,17 @@ export function LaserControl({ sessionId, paradigm }: Props) {
           disabled={duration < 1 || duration > 600000}
           className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
       </div>
-      <div className="flex items-center gap-2">
-        <label className="text-sm text-theme-text/60" title="Onset delay from trigger to laser activation">Delay (ms):</label>
-        <input type="number" value={onsetDelay} min={0} max={delayMax}
-          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, onsetDelay: Math.min(Math.max(0, +e.target.value), delayMax) } }))}
-          className="w-24 input-base" />
-        <button onClick={() => send(673, onsetDelay)}
-          disabled={onsetDelay < 0 || onsetDelay > delayMax}
-          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
-      </div>
+      {isPavlovian && (
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-theme-text/60" title="Onset delay from trigger to laser activation">Delay (ms):</label>
+          <input type="number" value={onsetDelay} min={0} max={delayMax}
+            onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, onsetDelay: Math.min(Math.max(0, +e.target.value), delayMax) } }))}
+            className="w-24 input-base" />
+          <button onClick={() => send(673, onsetDelay)}
+            disabled={onsetDelay < 0 || onsetDelay > delayMax}
+            className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+        </div>
+      )}
       <SquareWaveCanvas frequency={frequency} duration={duration} />
     </div>
   );

--- a/web/src/components/hardware/SLMControl.tsx
+++ b/web/src/components/hardware/SLMControl.tsx
@@ -7,9 +7,12 @@ interface Props {
 }
 
 export function SLMControl({ sessionId }: Props) {
-  const armed = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi.slm.armed ?? false);
+  const slm = useSessionStore((s) => s.sessions.get(sessionId)?.hardwareUi.slm);
+  const armed = slm?.armed ?? false;
+  const laserFrequency = slm?.laserFrequency ?? null;
+  const laserDuration = slm?.laserDuration ?? null;
   const updateHardwareUi = useSessionStore((s) => s.updateHardwareUi);
-  const send = (code: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code);
+  const send = (code: number, value?: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code, value);
 
   return (
     <div className="card">
@@ -27,6 +30,40 @@ export function SLMControl({ sessionId }: Props) {
           onClick={() => { send(1100); updateHardwareUi(sessionId, (prev) => ({ slm: { ...prev.slm, armed: false } })); }}
           className={`btn-sm ${!armed ? "btn-toggle-red-on" : "btn-toggle-red-off"}`}
         >Disarm</button>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-sm w-36 text-theme-text/60" title="Bookkeeping only — not tied to the LASER device's actual state">Laser Freq (Hz):</label>
+        <input
+          type="number"
+          min={1}
+          max={65535}
+          value={laserFrequency ?? ""}
+          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({
+            slm: { ...prev.slm, laserFrequency: e.target.value ? Number(e.target.value) : null },
+          }))}
+          placeholder="e.g. 40"
+          className="flex-1 input-base"
+        />
+        <button onClick={() => send(1102, laserFrequency ?? undefined)}
+          disabled={laserFrequency === null || laserFrequency < 1 || laserFrequency > 65535}
+          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-sm w-36 text-theme-text/60" title="Bookkeeping only — not tied to the LASER device's actual state">Laser Dur (ms):</label>
+        <input
+          type="number"
+          min={1}
+          max={600000}
+          value={laserDuration ?? ""}
+          onChange={(e) => updateHardwareUi(sessionId, (prev) => ({
+            slm: { ...prev.slm, laserDuration: e.target.value ? Number(e.target.value) : null },
+          }))}
+          placeholder="e.g. 5000"
+          className="flex-1 input-base"
+        />
+        <button onClick={() => send(1103, laserDuration ?? undefined)}
+          disabled={laserDuration === null || laserDuration < 1 || laserDuration > 600000}
+          className="btn-sm bg-accent text-accent-contrast disabled:opacity-50">Set</button>
       </div>
     </div>
   );

--- a/web/src/components/monitor/ParadigmFlowDiagram.tsx
+++ b/web/src/components/monitor/ParadigmFlowDiagram.tsx
@@ -152,8 +152,10 @@ function formatMs(ms: number): string {
 
 // ─── Laser Helpers ──────────────────────────────────────────────────
 
-function isLaserInChain(mode: LaserUiState["mode"]): boolean {
-  return mode !== "independent";
+// Operant paradigms: `contingency` is the authoritative chain-membership field
+// (mode is Pavlovian-only and can be stale here — see hardwareSummary.ts).
+function isLaserInChain(contingency: LaserUiState["contingency"]): boolean {
+  return contingency !== "independent";
 }
 
 function laserAppliesToTrial(mode: LaserUiState["mode"], trialType: "cs+" | "cs-"): boolean {
@@ -164,8 +166,11 @@ function laserAppliesToTrial(mode: LaserUiState["mode"], trialType: "cs+" | "cs-
   return false;
 }
 
-function addIndependentLaserAnnotation(bars: TimeBar[], hw: HardwareUiState): void {
-  if (hw.laser.armed && !isLaserInChain(hw.laser.mode)) {
+// isIndependent's source field differs by paradigm: Pavlovian's laser UI only ever
+// writes `mode` (never `contingency`), while operant's UI only ever writes
+// `contingency` — callers must pass the field appropriate to their paradigm.
+function addIndependentLaserAnnotation(bars: TimeBar[], hw: HardwareUiState, isIndependent: boolean): void {
+  if (hw.laser.armed && isIndependent) {
     const totalMs = Math.max(...bars.map((b) => b.endMs), 1);
     bars.push({
       lane: "laser",
@@ -178,13 +183,33 @@ function addIndependentLaserAnnotation(bars: TimeBar[], hw: HardwareUiState): vo
   }
 }
 
+// Groups trigger-driven devices that share the same onset time into one
+// "<verb> → X" arrow, and emits separate arrows for devices whose own
+// per-device delay puts them at a different onset time.
+function pushTriggerArrows(
+  arrows: CausalArrow[],
+  triggerEnd: number,
+  entries: { lane: LaneId; start: number }[],
+  verb = "press",
+): void {
+  const groups = new Map<number, LaneId[]>();
+  for (const { lane, start } of entries) {
+    const lanes = groups.get(start) ?? [];
+    lanes.push(lane);
+    groups.set(start, lanes);
+  }
+  for (const [start, lanes] of groups) {
+    const label = lanes.map((l) => LANE_LABELS[l].toLowerCase()).join(" + ");
+    arrows.push({ fromLane: "lever", fromEndMs: triggerEnd, toLanes: lanes, toStartMs: start, label: `${verb} → ${label}` });
+  }
+}
+
 // ─── Timeline Builders ───────────────────────────────────────────────
 
 interface ParadigmSettings {
   ratio: number;
   step: number;
   interval: number;
-  traceInterval: number;
 }
 
 function buildFRTimeline(hw: HardwareUiState, ps: ParadigmSettings): TrialTimeline {
@@ -195,55 +220,50 @@ function buildFRTimeline(hw: HardwareUiState, ps: ParadigmSettings): TrialTimeli
 
   // Press duration — notional 500ms for visualization
   const pressDur = 500;
-  let t = 0;
+  const t = 0;
 
   bars.push({ lane: "lever", startMs: t, endMs: t + pressDur, label: `PRESS x${ps.ratio}` });
   const pressEnd = t + pressDur;
-  t = pressEnd;
 
-  // Chain fires at press end — timeout starts here (concurrent with chain)
-  const chainFireMs = t;
+  // Every output device's onset originates from press onset + its own configured
+  // delay — no device's timing depends on another device's onset/duration.
+  const chainFireMs = pressEnd;
 
-  // CUE fires first in the chain (offsetMs=0 from chain fire)
   const cueDuration = hw.primaryCue.duration;
+  const cueStart = chainFireMs + hw.primaryCue.contingency.delay;
+  const cueEnd = cueStart + cueDuration;
   if (hw.primaryCue.armed) {
-    bars.push({ lane: "cue", startMs: t, endMs: t + cueDuration, label: "CUE", sublabel: `${cueDuration}ms` });
-  }
-  // Advance past cue duration (firmware uses cue duration offset even if disarmed)
-  t += cueDuration;
-
-  // Trace interval between CUE end and PUMP/LASER start
-  if (ps.traceInterval > 0) {
-    traces.push({ startMs: t, endMs: t + ps.traceInterval, label: `${ps.traceInterval}ms trace` });
-    t += ps.traceInterval;
+    bars.push({ lane: "cue", startMs: cueStart, endMs: cueEnd, label: "CUE", sublabel: `${cueDuration}ms` });
   }
 
-  // PUMP and LASER fire simultaneously after cue duration + trace
-  const rewardStart = t;
-  const rewardLanes: LaneId[] = [];
+  const pressArrowEntries: { lane: LaneId; start: number }[] = [];
+  if (hw.primaryCue.armed) pressArrowEntries.push({ lane: "cue", start: cueStart });
 
+  let pumpStart: number | null = null;
   if (hw.primaryPump.armed) {
-    bars.push({ lane: "pump", startMs: t, endMs: t + hw.primaryPump.duration, label: "INFUSION", sublabel: `${hw.primaryPump.duration}ms` });
-    rewardLanes.push("pump");
-  }
-  if (hw.laser.armed && isLaserInChain(hw.laser.mode)) {
-    bars.push({ lane: "laser", startMs: t, endMs: t + hw.laser.duration, label: "LASER", sublabel: `${hw.laser.duration}ms` });
-    rewardLanes.push("laser");
+    pumpStart = chainFireMs + hw.primaryPump.contingency.delay;
+    bars.push({ lane: "pump", startMs: pumpStart, endMs: pumpStart + hw.primaryPump.duration, label: "INFUSION", sublabel: `${hw.primaryPump.duration}ms` });
+    pressArrowEntries.push({ lane: "pump", start: pumpStart });
   }
 
-  // Causal arrows reflecting chain order
-  if (hw.primaryCue.armed && rewardLanes.length > 0) {
-    // Two arrows: press → cue, cue → pump/laser
-    arrows.push({ fromLane: "lever", fromEndMs: pressEnd, toLanes: ["cue"], toStartMs: chainFireMs, label: "press → cue" });
-    const rewardLabel = rewardLanes.map((l) => LANE_LABELS[l].toLowerCase()).join(" + ");
-    arrows.push({ fromLane: "cue", fromEndMs: chainFireMs + cueDuration, toLanes: rewardLanes, toStartMs: rewardStart, label: `cue → ${rewardLabel}` });
-  } else if (hw.primaryCue.armed) {
-    // Only cue, no pump/laser
-    arrows.push({ fromLane: "lever", fromEndMs: pressEnd, toLanes: ["cue"], toStartMs: chainFireMs, label: "press → cue" });
-  } else if (rewardLanes.length > 0) {
-    // CUE disarmed — press directly triggers pump/laser (offset still applies in firmware)
-    const rewardLabel = rewardLanes.map((l) => LANE_LABELS[l].toLowerCase()).join(" + ");
-    arrows.push({ fromLane: "lever", fromEndMs: pressEnd, toLanes: rewardLanes, toStartMs: rewardStart, label: `press → ${rewardLabel}` });
+  let laserStart: number | null = null;
+  if (hw.laser.armed && isLaserInChain(hw.laser.contingency)) {
+    laserStart = chainFireMs + hw.laser.onsetDelay;
+    bars.push({ lane: "laser", startMs: laserStart, endMs: laserStart + hw.laser.duration, label: "LASER", sublabel: `${hw.laser.duration}ms` });
+    pressArrowEntries.push({ lane: "laser", start: laserStart });
+  }
+
+  pushTriggerArrows(arrows, pressEnd, pressArrowEntries);
+
+  // Derived "trace interval" gap — only meaningful when the cue actually fires
+  // and a reward device's onset falls after the cue finishes (not a stored value).
+  if (hw.primaryCue.armed) {
+    if (pumpStart !== null && pumpStart > cueEnd) {
+      traces.push({ startMs: cueEnd, endMs: pumpStart, label: `${pumpStart - cueEnd}ms trace` });
+    }
+    if (laserStart !== null && laserStart > cueEnd && laserStart !== pumpStart) {
+      traces.push({ startMs: cueEnd, endMs: laserStart, label: `${laserStart - cueEnd}ms trace` });
+    }
   }
 
   // Timeout starts at chain fire time (concurrent with CUE), not after rewards
@@ -298,33 +318,53 @@ function buildVITimeline(hw: HardwareUiState, ps: ParadigmSettings): TrialTimeli
 function buildOmissionTimeline(hw: HardwareUiState, ps: ParadigmSettings): TrialTimeline {
   const bars: TimeBar[] = [];
   const arrows: CausalArrow[] = [];
+  const traces: TraceAnnotation[] = [];
   const holdDur = ps.interval || 5000;
-  let t = 0;
+  const t = 0;
 
   bars.push({ lane: "lever", startMs: t, endMs: t + holdDur, label: "NO PRESS", sublabel: `${holdDur}ms` });
   const holdEnd = t + holdDur;
-  t = holdEnd;
 
-  const rewardLanes: LaneId[] = [];
+  // Every output device's onset originates from the absence-timer trigger + its
+  // own configured delay — no device's timing depends on another device's onset.
+  const pressArrowEntries: { lane: LaneId; start: number }[] = [];
+
+  let cueEnd: number | null = null;
   if (hw.primaryCue.armed) {
-    bars.push({ lane: "cue", startMs: t, endMs: t + hw.primaryCue.duration, label: "CUE", sublabel: `${hw.primaryCue.duration}ms` });
-    rewardLanes.push("cue");
+    const cueStart = holdEnd + hw.primaryCue.contingency.delay;
+    cueEnd = cueStart + hw.primaryCue.duration;
+    bars.push({ lane: "cue", startMs: cueStart, endMs: cueEnd, label: "CUE", sublabel: `${hw.primaryCue.duration}ms` });
+    pressArrowEntries.push({ lane: "cue", start: cueStart });
   }
+
+  let pumpStart: number | null = null;
   if (hw.primaryPump.armed) {
-    bars.push({ lane: "pump", startMs: t, endMs: t + hw.primaryPump.duration, label: "INFUSION", sublabel: `${hw.primaryPump.duration}ms` });
-    rewardLanes.push("pump");
-  }
-  if (hw.laser.armed && isLaserInChain(hw.laser.mode)) {
-    bars.push({ lane: "laser", startMs: t, endMs: t + hw.laser.duration, label: "LASER", sublabel: `${hw.laser.duration}ms` });
-    rewardLanes.push("laser");
+    pumpStart = holdEnd + hw.primaryPump.contingency.delay;
+    bars.push({ lane: "pump", startMs: pumpStart, endMs: pumpStart + hw.primaryPump.duration, label: "INFUSION", sublabel: `${hw.primaryPump.duration}ms` });
+    pressArrowEntries.push({ lane: "pump", start: pumpStart });
   }
 
-  if (rewardLanes.length > 0) {
-    const rewardLabel = rewardLanes.map((l) => LANE_LABELS[l].toLowerCase()).join(" + ");
-    arrows.push({ fromLane: "lever", fromEndMs: holdEnd, toLanes: rewardLanes, toStartMs: t, label: `no press → ${rewardLabel}` });
+  let laserStart: number | null = null;
+  if (hw.laser.armed && isLaserInChain(hw.laser.contingency)) {
+    laserStart = holdEnd + hw.laser.onsetDelay;
+    bars.push({ lane: "laser", startMs: laserStart, endMs: laserStart + hw.laser.duration, label: "LASER", sublabel: `${hw.laser.duration}ms` });
+    pressArrowEntries.push({ lane: "laser", start: laserStart });
   }
 
-  return { title: "Omission Trial", bars, arrows, traces: [], timeouts: [], loopLabel: "press resets timer" };
+  pushTriggerArrows(arrows, holdEnd, pressArrowEntries, "no press");
+
+  // Derived "trace interval" gap — only meaningful when the cue actually fires
+  // and a reward device's onset falls after the cue finishes (not a stored value).
+  if (cueEnd !== null) {
+    if (pumpStart !== null && pumpStart > cueEnd) {
+      traces.push({ startMs: cueEnd, endMs: pumpStart, label: `${pumpStart - cueEnd}ms trace` });
+    }
+    if (laserStart !== null && laserStart > cueEnd && laserStart !== pumpStart) {
+      traces.push({ startMs: cueEnd, endMs: laserStart, label: `${laserStart - cueEnd}ms trace` });
+    }
+  }
+
+  return { title: "Omission Trial", bars, arrows, traces, timeouts: [], loopLabel: "press resets timer" };
 }
 
 function buildPavlovianTimeline(
@@ -672,7 +712,7 @@ function TimelineDiagram({ timeline, isDark, containerW }: { timeline: TrialTime
 interface ParadigmFlowDiagramProps {
   paradigm: string;
   hardwareUi: HardwareUiState;
-  paradigmSettings: { ratio: number; step: number; interval: number; traceInterval: number } | null;
+  paradigmSettings: { ratio: number; step: number; interval: number } | null;
   pavlovianParams: Record<number, number> | null;
 }
 
@@ -707,7 +747,7 @@ export function ParadigmFlowDiagram({
       buildPavlovianTimeline("cs+", hardwareUi, pavlovianParams),
       buildPavlovianTimeline("cs-", hardwareUi, pavlovianParams),
     ];
-    for (const tl of timelines) addIndependentLaserAnnotation(tl.bars, hardwareUi);
+    for (const tl of timelines) addIndependentLaserAnnotation(tl.bars, hardwareUi, hardwareUi.laser.mode === "independent");
     return (
       <div ref={containerRef} className="space-y-3">
         {timelines.map((tl, i) => (
@@ -717,7 +757,7 @@ export function ParadigmFlowDiagram({
     );
   }
 
-  const ps = paradigmSettings ?? { ratio: 1, step: 1, interval: 0, traceInterval: 0 };
+  const ps = paradigmSettings ?? { ratio: 1, step: 1, interval: 0 };
 
   let timeline: TrialTimeline;
   switch (p) {
@@ -737,7 +777,7 @@ export function ParadigmFlowDiagram({
       return null;
   }
 
-  addIndependentLaserAnnotation(timeline.bars, hardwareUi);
+  addIndependentLaserAnnotation(timeline.bars, hardwareUi, !isLaserInChain(hardwareUi.laser.contingency));
 
   return (
     <div ref={containerRef}>

--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -130,9 +130,6 @@ export function SessionStartModal() {
         if (paradigm === "omission") {
           await client?.sendCommand(activeSessionId, 203, session.paradigmSettings.interval);
         }
-        if (paradigm === "fr" || paradigm === "pr" || paradigm === "vi") {
-          await client?.sendCommand(activeSessionId, 220, session.paradigmSettings.traceInterval);
-        }
       }
 
       // Send hardware state to firmware — only for armed devices.
@@ -242,12 +239,6 @@ export function SessionStartModal() {
                   <>
                     <span className="text-theme-text/60">Interval:</span>
                     <span className="font-mono">{session.paradigmSettings.interval} ms</span>
-                  </>
-                )}
-                {(paradigm === "fr" || paradigm === "pr" || paradigm === "vi") && (
-                  <>
-                    <span className="text-theme-text/60">Trace Interval:</span>
-                    <span className="font-mono">{session.paradigmSettings.traceInterval} ms</span>
                   </>
                 )}
               </div>

--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -166,15 +166,28 @@ export function SessionStartModal() {
 
       // Send laser mode + Pavlovian-specific commands
       const laserState = hw.laser;
-      if (laserState?.mode) {
-        // For trial-paired modes, send contingent (681) first, then filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
-          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+      if (isPavlovian) {
+        // Pavlovian: `mode` (+ `phase`) is authoritative — its UI never touches `contingency`.
+        if (laserState?.mode) {
+          // For trial-paired modes, send contingent (681) first, then filter command
+          if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
+            await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+          }
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode as keyof typeof LASER_MODE_COMMANDS]);
         }
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode as keyof typeof LASER_MODE_COMMANDS]);
-      }
-      if (laserPhaseActive(isPavlovian, laserState?.mode, laserState?.phase)) {
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase as keyof typeof PAV_LASER_PHASE_COMMANDS]);
+        if (laserPhaseActive(isPavlovian, laserState?.mode, laserState?.phase)) {
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase as keyof typeof PAV_LASER_PHASE_COMMANDS]);
+        }
+      } else if (laserState?.contingency) {
+        // Operant: `contingency` is authoritative routing — `mode` is Pavlovian-only and can be
+        // stale here, so it must NOT drive this dispatch (mirrors hardwareSummary.ts's laserParts).
+        const contingencyCommand = {
+          any: LASER_MODE_COMMANDS.contingent,
+          rh: LASER_MODE_COMMANDS.rh_lever,
+          lh: LASER_MODE_COMMANDS.lh_lever,
+          independent: LASER_MODE_COMMANDS.independent,
+        }[laserState.contingency];
+        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, contingencyCommand);
       }
 
       await getClientForSession(activeSessionId)?.startProgram(activeSessionId);

--- a/web/src/components/monitor/hardwareSummary.ts
+++ b/web/src/components/monitor/hardwareSummary.ts
@@ -126,7 +126,10 @@ function microscopeParts(s: MicroscopeUiState): string[] {
 }
 
 function slmParts(s: SlmUiState): string[] {
-  return [`Pin:${s.pin}`];
+  const parts: string[] = [`Pin:${s.pin}`];
+  if (s.laserFrequency != null) parts.push(`${s.laserFrequency}Hz`);
+  if (s.laserDuration != null) parts.push(`${s.laserDuration}ms`);
+  return parts;
 }
 
 // Exhaustive per-device formatters. The mapped-type key set is the drift guard (see above).

--- a/web/src/components/program/ParadigmSettings.tsx
+++ b/web/src/components/program/ParadigmSettings.tsx
@@ -14,16 +14,13 @@ export function ParadigmSettings({ sessionId, paradigm }: Props) {
   const [ratio, setRatio] = useState(() => session?.paradigmSettings?.ratio ?? 1);
   const [step, setStep] = useState(() => session?.paradigmSettings?.step ?? 1);
   const [interval, setInterval_] = useState(() => session?.paradigmSettings?.interval ?? 30000);
-  const [traceInterval, setTraceInterval] = useState(() => session?.paradigmSettings?.traceInterval ?? 0);
 
   // Sync to store whenever values change
   useEffect(() => {
-    setParadigmSettings(sessionId, { ratio, step, interval, traceInterval });
-  }, [ratio, step, interval, traceInterval, sessionId]);
+    setParadigmSettings(sessionId, { ratio, step, interval });
+  }, [ratio, step, interval, sessionId]);
 
   const send = (code: number, value: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code, value);
-
-  const showTrace = paradigm === "fr" || paradigm === "pr" || paradigm === "vi";
 
   return (
     <div className="card">
@@ -62,16 +59,6 @@ export function ParadigmSettings({ sessionId, paradigm }: Props) {
           <input type="number" value={interval} onChange={(e) => setInterval_(+e.target.value)}
             className="w-24 input-base" />
           <button onClick={() => send(203, interval)} className="btn-sm bg-accent text-accent-contrast">Set</button>
-        </div>
-      )}
-
-      {/* Issue #2C: Trace Interval */}
-      {showTrace && (
-        <div className="flex items-center gap-2">
-          <label className="text-sm w-24 text-theme-text/60">Trace Interval (ms):</label>
-          <input type="number" value={traceInterval} onChange={(e) => setTraceInterval(+e.target.value)}
-            className="w-24 input-base" />
-          <button onClick={() => send(220, traceInterval)} className="btn-sm bg-accent text-accent-contrast">Set</button>
         </div>
       )}
 

--- a/web/src/components/program/ProgramPanel.tsx
+++ b/web/src/components/program/ProgramPanel.tsx
@@ -132,7 +132,7 @@ export function ProgramPanel() {
         }
         if (mapping.params) {
           for (const [paramKey, code] of Object.entries(mapping.params)) {
-            if (state[paramKey] !== undefined) {
+            if (state[paramKey] !== undefined && state[paramKey] !== null) {
               let value = state[paramKey];
               if (paramKey === "leverFilter") {
                 if (!leverFilterActive(state[paramKey] as "none" | "rh" | "lh" | undefined, pressContingent)) continue;
@@ -234,7 +234,7 @@ export function ProgramPanel() {
         }
         if (mapping.params) {
           for (const [paramKey, code] of Object.entries(mapping.params)) {
-            if (state[paramKey] !== undefined) {
+            if (state[paramKey] !== undefined && state[paramKey] !== null) {
               let value = state[paramKey];
               if (paramKey === "leverFilter") {
                 if (!leverFilterActive(state[paramKey] as "none" | "rh" | "lh" | undefined, pressContingent)) continue;

--- a/web/src/components/program/ProgramPanel.tsx
+++ b/web/src/components/program/ProgramPanel.tsx
@@ -173,7 +173,6 @@ export function ProgramPanel() {
         }
       } else {
         await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,201, preset.paradigmSettings.ratio);
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,220, preset.paradigmSettings.traceInterval);
       }
     }
 

--- a/web/src/components/program/ProgramPanel.tsx
+++ b/web/src/components/program/ProgramPanel.tsx
@@ -151,19 +151,31 @@ export function ProgramPanel() {
         }
       }
 
-      // 2b. Send laser mode command if preset specifies a mode
+      // 2b. Send laser mode/contingency command if preset specifies one.
+      // Pavlovian: `mode` (+ `phase`) is authoritative. Operant: `contingency` is authoritative —
+      // `mode` is Pavlovian-only and can be stale, so it must not drive operant dispatch (mirrors
+      // hardwareSummary.ts's laserParts() and SessionStartModal.tsx's session-start dispatch).
       const laserState = preset.hardware.laser as LaserUiState | undefined;
-      if (laserState?.mode) {
-        // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
-          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+      if (isPav) {
+        if (laserState?.mode) {
+          // Pavlovian trial-paired modes require contingent (681) before filter command
+          if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
+            await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+          }
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
         }
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
-      }
-
-      // 2c. Send laser phase command if Pavlovian preset specifies a phase
-      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        // 2c. Send laser phase command if Pavlovian preset specifies a phase
+        if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        }
+      } else if (laserState?.contingency) {
+        const contingencyCommand = {
+          any: LASER_MODE_COMMANDS.contingent,
+          rh: LASER_MODE_COMMANDS.rh_lever,
+          lh: LASER_MODE_COMMANDS.lh_lever,
+          independent: LASER_MODE_COMMANDS.independent,
+        }[laserState.contingency];
+        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, contingencyCommand);
       }
 
       // 3. Send paradigm-specific commands
@@ -234,19 +246,29 @@ export function ProgramPanel() {
         }
       }
 
-      // Send laser mode command if preset specifies a mode
+      // Send laser mode/contingency command if preset specifies one (see applySessionPreset
+      // above for why Pavlovian uses `mode` and operant uses `contingency`).
       const laserState = preset.hardware.laser as LaserUiState | undefined;
-      if (laserState?.mode) {
-        // Pavlovian trial-paired modes require contingent (681) before filter command
-        if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
-          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+      if (isPav) {
+        if (laserState?.mode) {
+          // Pavlovian trial-paired modes require contingent (681) before filter command
+          if (laserState.mode !== "independent" && laserState.mode !== "contingent" && laserState.mode !== "rh_lever" && laserState.mode !== "lh_lever") {
+            await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,681);
+          }
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
         }
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,LASER_MODE_COMMANDS[laserState.mode]);
-      }
-
-      // Send laser phase command if preset specifies a phase
-      if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
-        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        // Send laser phase command if preset specifies a phase
+        if (laserPhaseActive(isPav, laserState?.mode, laserState?.phase)) {
+          await getClientForSession(activeSessionId)?.sendCommand(activeSessionId,PAV_LASER_PHASE_COMMANDS[laserState.phase]);
+        }
+      } else if (laserState?.contingency) {
+        const contingencyCommand = {
+          any: LASER_MODE_COMMANDS.contingent,
+          rh: LASER_MODE_COMMANDS.rh_lever,
+          lh: LASER_MODE_COMMANDS.lh_lever,
+          independent: LASER_MODE_COMMANDS.independent,
+        }[laserState.contingency];
+        await getClientForSession(activeSessionId)?.sendCommand(activeSessionId, contingencyCommand);
       }
     }
   };

--- a/web/src/components/program/devicePresets.ts
+++ b/web/src/components/program/devicePresets.ts
@@ -42,5 +42,5 @@ export const PRESET_COMMAND_MAP: Record<string, { arm: number; disarm: number; p
   laser:         { arm: 601,  disarm: 600,  params: { frequency: 671, duration: 672, delay: 673 } },
   lickCircuit:   { arm: 501,  disarm: 500 },
   microscope:    { arm: 901,  disarm: 900 },
-  slm:           { arm: 1101, disarm: 1100 },
+  slm:           { arm: 1101, disarm: 1100, params: { laserFrequency: 1102, laserDuration: 1103 } },
 };

--- a/web/src/components/program/presets/deviceMetadata.ts
+++ b/web/src/components/program/presets/deviceMetadata.ts
@@ -34,7 +34,6 @@ const DEFAULT_PARADIGM_SETTINGS: SessionPreset["paradigmSettings"] = {
   ratio: 1,
   step: 1,
   interval: 0,
-  traceInterval: 0,
 };
 
 const DEFAULT_LIMIT_SETTINGS: SessionPreset["limitDefaults"] = {

--- a/web/src/components/program/presets/frSaPresets.ts
+++ b/web/src/components/program/presets/frSaPresets.ts
@@ -38,7 +38,7 @@ const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
   laser:        { armed: false, frequency: 40, duration: 5000, mode: "contingent" as const, contingency: "any" as const, onsetDelay: 0 },
   lickCircuit:  { armed: false },
   microscope:   { armed: false, frameRate: null, frameAveraging: null },
-  slm:          { armed: false, pin: 11 },
+  slm:          { armed: false, pin: 11, laserFrequency: null, laserDuration: null },
   secondaryCue: { armed: false, frequency: 2900, duration: 1000,
     contingency: { leverFilter: "none", delay: 0 } },
   secondaryPump: { armed: false, duration: 3000,

--- a/web/src/components/program/presets/frSaPresets.ts
+++ b/web/src/components/program/presets/frSaPresets.ts
@@ -51,7 +51,6 @@ const PARADIGM_SETTINGS: SessionPreset["paradigmSettings"] = {
   ratio: 1,
   step: 1,
   interval: 30000,
-  traceInterval: 0,
 };
 
 /* ── Presets ───────────────────────────────────────────────────────── */

--- a/web/src/components/program/presets/pavlovianPresets.ts
+++ b/web/src/components/program/presets/pavlovianPresets.ts
@@ -40,7 +40,6 @@ const PARADIGM_SETTINGS: SessionPreset["paradigmSettings"] = {
   ratio: 1,
   step: 1,
   interval: 0,
-  traceInterval: 0,
 };
 
 /* ── Presets ───────────────────────────────────────────────────────── */

--- a/web/src/components/program/presets/pavlovianPresets.ts
+++ b/web/src/components/program/presets/pavlovianPresets.ts
@@ -31,7 +31,7 @@ const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
   laser:       { armed: false, frequency: 40, duration: 5000, mode: "cs_plus" as const, phase: "reward" as const, contingency: "any" as const, onsetDelay: 0 },
   lickCircuit: { armed: true },
   microscope:  { armed: false, frameRate: null, frameAveraging: null },
-  slm:         { armed: false, pin: 11 },
+  slm:         { armed: false, pin: 11, laserFrequency: null, laserDuration: null },
 };
 
 /* ── Dummy paradigm settings (not used by Pavlovian, required by type) */

--- a/web/src/components/program/presets/types.ts
+++ b/web/src/components/program/presets/types.ts
@@ -19,7 +19,6 @@ export interface SessionPreset {
     ratio: number;
     step: number;
     interval: number;
-    traceInterval: number;
   };
   pavlovianParams?: Record<number, number>;
   limitDefaults: {

--- a/web/src/components/tutorial/tours/firstSession.ts
+++ b/web/src/components/tutorial/tours/firstSession.ts
@@ -14,8 +14,6 @@ function formatParadigmSummary(session: Session): string | null {
     if (s.step > 0) parts.push(`Step: ${s.step}`);
   } else if (p.includes("vi") || p.includes("variable")) {
     if (s.interval > 0) parts.push(`Interval: ${s.interval}s`);
-  } else if (p.includes("omission") || p.includes("pavlov")) {
-    if (s.traceInterval > 0) parts.push(`Trace interval: ${s.traceInterval}s`);
   }
 
   if (parts.length === 0) return null;

--- a/web/src/store/useSessionStore.ts
+++ b/web/src/store/useSessionStore.ts
@@ -22,7 +22,7 @@ interface SessionStore {
   setFirmwareInfo: (id: string, info: FirmwareConfig) => void;
   setUploadProgress: (id: string, percent: number, stage: string) => void;
   setPavlovianParams: (id: string, params: Record<number, number>) => void;
-  setParadigmSettings: (id: string, settings: { ratio: number; step: number; interval: number; traceInterval: number }) => void;
+  setParadigmSettings: (id: string, settings: { ratio: number; step: number; interval: number }) => void;
   setLimitSettings: (id: string, settings: { limitType: string; timeLimit: number; infusionLimit: number; delay: number }) => void;
   setParadigm: (id: string, paradigm: string) => void;
   setBoard: (id: string, board: BoardType) => void;

--- a/web/src/store/useSessionStore.ts
+++ b/web/src/store/useSessionStore.ts
@@ -55,7 +55,7 @@ export const defaultHardwareUiState = (): HardwareUiState => ({
   laser: { armed: false, frequency: 40, duration: 5000, mode: "contingent", phase: "reward", contingency: "any", onsetDelay: 0 },
   lickCircuit: { armed: false },
   microscope: { armed: false, frameRate: null, frameAveraging: null },
-  slm: { armed: false, pin: 11 },
+  slm: { armed: false, pin: 11, laserFrequency: null, laserDuration: null },
   testMode: false,
 });
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -131,7 +131,7 @@ export interface Session {
   pausedTime: number;
   pauseStartTime: number | null;
   pavlovianParams: Record<number, number> | null;
-  paradigmSettings: { ratio: number; step: number; interval: number; traceInterval: number } | null;
+  paradigmSettings: { ratio: number; step: number; interval: number } | null;
   limitSettings: { limitType: string; timeLimit: number; infusionLimit: number; delay: number } | null;
   trialCount: number;
   csPlusCount: number;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -62,6 +62,11 @@ export interface MicroscopeUiState extends DeviceArmState {
 
 export interface SlmUiState extends DeviceArmState {
   pin: number;
+  /** Bookkeeping only — records what the laser's frequency/duration should have
+   *  been, so a session record survives if the laser itself misbehaves. Not
+   *  tied to the LASER device's actual live state. */
+  laserFrequency: number | null;
+  laserDuration: number | null;
 }
 
 export interface HardwareUiState {


### PR DESCRIPTION
## Intent
Frontend half of the output-device onset-delay redesign (backend/firmware already shipped in Otis-Lab-MUSC/reacher#46): reformat LASER's "Contingent on" control to match CUE/PUMP's shared ContingencySection, fix the pre-session timeline diagram to reflect real per-device delays, and add SLM SYNC laser frequency/duration record-keeping fields.

## Approach the AI took
**Commit 1 – remove traceInterval:** Deleted the `traceInterval` field/UI/command (superseded by per-device onset delays) from `ParadigmSettings.tsx`, all preset files, `useSessionStore.ts`, `types/index.ts`, the cmd-220 sends in `ConfigurationPanel.tsx`/`ProgramPanel.tsx`/`SessionStartModal.tsx`, the tutorial tour text, and — found only by checking — the Python terminal CLI (`cli/app.py`), a separate peer client to the same REST API that had its own independent `trace_interval` command mapping, dataclass default, and menu entry.

**Commit 2 – laser UI + dispatch fix:** Replaced `LaserControl.tsx`'s bespoke purple-button "Contingent on" block with the shared `ContingencySection` pattern (lever-filter buttons + grouped delay input), adding a 4th "Independent" option. Rewrote `ParadigmFlowDiagram.tsx`'s FR/PR/VI/Omission timeline builders to draw each device's bar at press-onset + its own configured delay (previously hardcoded to fire right after cue+trace), with a derived "trace interval" gap annotation computed at render time instead of read from a stored value. Fixed a stale-field bug where `isLaserInChain`/`addIndependentLaserAnnotation` read the Pavlovian-only `mode` field for operant paradigms instead of the authoritative `contingency` field, and the identical bug in `SessionStartModal.tsx`'s and `ConfigurationPanel.tsx`/`ProgramPanel.tsx`'s session-start/preset-apply dispatch (operant sessions were silently re-sending `LASER_MODE_CONTINGENT` regardless of the user's actual RH/LH/Independent selection, since the operant UI never updates `mode`).

**Commit 3 – SLM bookkeeping:** Added `laserFrequency`/`laserDuration` fields to `SlmUiState` and `SLMControl.tsx` (manually-entered, not tied to the real LASER device), wired to the new backend commands 1102/1103. Fixed a null-vs-undefined bug in the preset-apply param loops (`!== undefined` → also `!== null`) that would have silently zeroed these nullable fields when applying any built-in preset.

## Risk
Touches session-start and preset-apply command dispatch paths shared by every paradigm — a mistake here could send the wrong hardware command at session start. Mitigated by a 4-lens review board (ai/security/logic/rigor) that caught and fixed 7 issues (including 2 of the above) before this PR, and `tsc -b && vite build` passing clean.

## Not tested
No manual walkthrough in a running browser against a live backend (no dev server / hardware exercised this session) — verified via TypeScript compilation only. The corresponding backend command codes (reacher#46) were verified against the full pytest suite and firmware compile, but the two repos haven't been run together end-to-end.

Closes #97