### PR TITLE
feat: add SLM FRAMES stat, rename FRAMES to 2P FRAMES

### DIFF
--- a/web/src/components/monitor/LiveStats.tsx
+++ b/web/src/components/monitor/LiveStats.tsx
@@ -42,6 +42,10 @@ export function LiveStats({ session }: Props) {
     (e) => e.device === "LICK" && e.event === "LICK"
   ).length;
 
+  const slmFrameCount = session.behaviorData.filter(
+    (e) => e.device === "SLM" && e.event === "TIMESTAMP"
+  ).length;
+
   const sessionStats: { label: string; value: string | number }[] = [
     { label: "INFUSIONS", value: session.infusionCount },
     { label: "LICKS", value: lickCount },
@@ -52,7 +56,8 @@ export function LiveStats({ session }: Props) {
           { label: "CS-", value: session.csMinusCount },
         ]
       : []),
-    { label: "FRAMES", value: session.frameData.length },
+    { label: "2P FRAMES", value: session.frameData.length },
+    { label: "SLM FRAMES", value: slmFrameCount },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- Renames the Session page's "FRAMES" stat to "2P FRAMES" (disambiguating it as microscope-specific; `session.frameData.length`, data source unchanged)
- Adds an adjacent "SLM FRAMES" stat, derived from `session.behaviorData` (`device === "SLM" && event === "TIMESTAMP"`), mirroring the existing `lickCount` filter pattern — SLM sync ticks arrive via the generic WS `"event"` message rather than a dedicated array, so no backend/WS-type/store changes were needed

Closes #99

## Review notes
Ran through the full four-lens review board (ai-reviewer, security-reviewer, logic-reviewer, rigor-reviewer):
- logic + security: pass, no findings
- ai-reviewer + rigor-reviewer both flagged the same pre-existing gap: WS-reconnect recovery replaces the entire `behaviorData` array from `GET /behavior`, which doesn't include SLM entries (they live in a separate backend list), so the **live** SLM FRAMES tally can dip on reconnect mid-session. Recorded/exported data is unaffected — only the live UI count. This gap already exists for 2P FRAMES today; this PR extends it to a second stat rather than introducing a new class of bug. Filed as a separate follow-up: #100 (needs-scoping, spans both `reacher` and `labrynth`).

## Test plan
- [x] `npx tsc -b --noEmit` — passes clean
- [ ] `npm run lint` — repo has no `eslint.config.js` on `main` (pre-existing infra gap, unrelated to this change); ESLint currently cannot run at all
- [ ] Manual: run backend + frontend locally, arm SLM + microscope, trigger both sync inputs, confirm "2P FRAMES" and "SLM FRAMES" both render and increment correctly on the Session page (cross-check against `EventTimeline`)