### PR TITLE
fix(program): correct FR pump onset delay, zero blank-state default

### DIFF
--- a/web/src/components/program/presets/frSaPresets.ts
+++ b/web/src/components/program/presets/frSaPresets.ts
@@ -31,7 +31,7 @@ const CORE_HARDWARE: Partial<HardwareUiState> = {
 
 const PUMP_HARDWARE: Partial<HardwareUiState> = {
   primaryPump: { armed: true, duration: 2000,
-    contingency: { leverFilter: "rh", delay: 0 } },
+    contingency: { leverFilter: "rh", delay: 1600 } },
 };
 
 const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
@@ -108,7 +108,7 @@ export const SA_EXTINCTION_PRESET: SessionPreset = {
     primaryCue:  { armed: false, frequency: 8000, duration: 1600,
       contingency: { leverFilter: "none", delay: 0 } },
     primaryPump: { armed: false, duration: 2000,
-      contingency: { leverFilter: "none", delay: 0 } },
+      contingency: { leverFilter: "none", delay: 1600 } },
     ...OPTIONAL_HARDWARE,
   },
   paradigmSettings: PARADIGM_SETTINGS,

--- a/web/src/store/useSessionStore.ts
+++ b/web/src/store/useSessionStore.ts
@@ -46,13 +46,13 @@ const DEFAULT_CONTINGENCY = (): ContingencyConfig => ({
 });
 
 export const defaultHardwareUiState = (): HardwareUiState => ({
-  rhLever: { armed: false, timeout: 20000, ratio: 1 },
-  lhLever: { armed: false, timeout: 20000, ratio: 1 },
-  primaryCue:   { armed: false, frequency: 2900, duration: 1000, contingency: DEFAULT_CONTINGENCY() },
-  secondaryCue: { armed: false, frequency: 2900, duration: 1000, contingency: DEFAULT_CONTINGENCY() },
-  primaryPump:  { armed: false, duration: 3000, contingency: DEFAULT_CONTINGENCY() },
-  secondaryPump: { armed: false, duration: 3000, contingency: DEFAULT_CONTINGENCY() },
-  laser: { armed: false, frequency: 40, duration: 5000, mode: "contingent", phase: "reward", contingency: "any", onsetDelay: 0 },
+  rhLever: { armed: false, timeout: 0, ratio: 1 },
+  lhLever: { armed: false, timeout: 0, ratio: 1 },
+  primaryCue:   { armed: false, frequency: 0, duration: 0, contingency: DEFAULT_CONTINGENCY() },
+  secondaryCue: { armed: false, frequency: 0, duration: 0, contingency: DEFAULT_CONTINGENCY() },
+  primaryPump:  { armed: false, duration: 0, contingency: DEFAULT_CONTINGENCY() },
+  secondaryPump: { armed: false, duration: 0, contingency: DEFAULT_CONTINGENCY() },
+  laser: { armed: false, frequency: 0, duration: 0, mode: "contingent", phase: "reward", contingency: "any", onsetDelay: 0 },
   lickCircuit: { armed: false },
   microscope: { armed: false, frameRate: null, frameAveraging: null },
   slm: { armed: false, pin: 11, laserFrequency: null, laserDuration: null },


### PR DESCRIPTION
## Summary
- Fixes the FR self-administration presets (`SA High/Mid/Low`, `SA Extinction`): `primaryPump.contingency.delay` was `0`, which under the old cue-chained reward model meant "right after the cue" but under the current per-device onset-delay firmware model means "simultaneous with the cue." Sets it to `1600` (matching the primary cue's duration) so the pump fires right as the tone ends.
- Zeroes `defaultHardwareUiState()` — the shared "no preset selected" template used by every paradigm — so a freshly-opened session starts fully unarmed and zeroed instead of showing non-zero placeholder values.

Closes #104. Companion firmware fix: Otis-Lab-MUSC/reacher#49 / Otis-Lab-MUSC/reacher#50.

## Test plan
- [x] `npm run build` (tsc + vite) — passes
- [ ] Load the `SA High Day` preset, start a session, confirm the pump fires ~1600ms after cue onset instead of simultaneously
- [ ] Open a fresh session with no preset selected, confirm every device shows unarmed + zeroed fields