### PR TITLE
feat: hide two-photon controls for UNO-class boards

### DIFF
--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -92,6 +92,7 @@ export function ConfigurationPanel() {
 
   const paradigm = session?.paradigm?.toLowerCase();
   const isPav = paradigm === "pavlovian";
+  const board = session?.board;
 
   // Fetch commands for hardware section
   useEffect(() => {
@@ -622,14 +623,16 @@ export function ConfigurationPanel() {
                 </div>
               </section>
 
-              {/* Two-Photon Devices */}
-              <section className="space-y-4 pt-6">
-                <h4 className="text-sm font-semibold text-theme-text/70 uppercase tracking-wide">Two-Photon Devices</h4>
-                <div className="grid gap-4 lg:grid-cols-2">
-                  <MicroscopeControl sessionId={activeSessionId} />
-                  <SLMControl sessionId={activeSessionId} />
-                </div>
-              </section>
+              {/* Two-Photon Devices — not present on UNO-class boards (e.g. the fr_lite firmware) */}
+              {board !== "uno" && (
+                <section className="space-y-4 pt-6">
+                  <h4 className="text-sm font-semibold text-theme-text/70 uppercase tracking-wide">Two-Photon Devices</h4>
+                  <div className="grid gap-4 lg:grid-cols-2">
+                    <MicroscopeControl sessionId={activeSessionId} />
+                    <SLMControl sessionId={activeSessionId} />
+                  </div>
+                </section>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Intent
Companion to `Otis-Lab-MUSC/reacher#51` / reacher#52 — the reacher backend gained a new UNO-compatible `fr_lite` firmware that drops Microscope + SLM (two-photon sync) since neither fits an ATmega328P's flash/RAM budget. The frontend still rendered the "Two-Photon Devices" controls unconditionally, which would be misleading/non-functional against that firmware.

## Approach the AI took
Gated `ConfigurationPanel.tsx`'s "Two-Photon Devices" section on `session.board !== "uno"`, mirroring the file's existing `paradigm !== "pavlovian"` inline-JSX gating pattern. `session.board` (`"uno" | "mega"`) is already populated post-upload and post-connect (USB VID/PID detection) — no new plumbing needed. Verified with `tsc --noEmit` (clean).

## Risk
FILL IN: <what could go wrong or break>

## Not tested
FILL IN: <what was not covered by testing>

Part of Otis-Lab-MUSC/reacher#51 (companion to reacher PR #52; close reacher#51 manually once both merge)
