### PR TITLE
feat: add session preset menu for fr_lite paradigm (#107)

### DIFF
--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -152,8 +152,11 @@ export const listBoards = async () => ({
   ] as BoardInfo[],
 });
 
-export const listParadigms = async (_board?: string) => ({
-  paradigms: ["fr", "pr", "vi", "omission", "pavlovian"],
+export const listParadigms = async (board?: string) => ({
+  paradigms:
+    board?.toLowerCase() === "uno"
+      ? ["fr_lite"]
+      : ["fr", "pr", "vi", "omission", "pavlovian"],
 });
 
 export const uploadFirmware = async (id: string, paradigm: string, board: string = "mega") => {

--- a/web/src/components/hardware/LeverControl.tsx
+++ b/web/src/components/hardware/LeverControl.tsx
@@ -27,7 +27,7 @@ export function LeverControl({ sessionId, side, paradigm }: Props) {
   const send = (code: number, value?: number) => getClientForSession(sessionId)?.sendCommand(sessionId, code, value);
 
   const showTimeout = paradigm !== "omission" && paradigm !== "pavlovian";
-  const showRatio = paradigm === "fr" || paradigm === "pr";
+  const showRatio = paradigm === "fr" || paradigm === "pr" || paradigm === "fr_lite";
 
   return (
     <div className="card">

--- a/web/src/components/monitor/ParadigmFlowDiagram.tsx
+++ b/web/src/components/monitor/ParadigmFlowDiagram.tsx
@@ -762,6 +762,7 @@ export function ParadigmFlowDiagram({
   let timeline: TrialTimeline;
   switch (p) {
     case "fr":
+    case "fr_lite":
       timeline = buildFRTimeline(hardwareUi, ps);
       break;
     case "pr":

--- a/web/src/components/monitor/SessionStartModal.tsx
+++ b/web/src/components/monitor/SessionStartModal.tsx
@@ -118,7 +118,7 @@ export function SessionStartModal() {
       // on remote sessions).  Mirrors the codes used in ConfigurationPanel.tsx.
       if (session.paradigmSettings && paradigm !== "pavlovian") {
         const client = getClientForSession(activeSessionId);
-        if (paradigm === "fr" || paradigm === "pr") {
+        if (paradigm === "fr" || paradigm === "pr" || paradigm === "fr_lite") {
           await client?.sendCommand(activeSessionId, 201, session.paradigmSettings.ratio);
         }
         if (paradigm === "pr") {
@@ -236,7 +236,7 @@ export function SessionStartModal() {
             <h3 className="text-sm font-medium text-theme-text/60 uppercase tracking-wide mb-2">Program Settings</h3>
             {session.paradigmSettings ? (
               <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                {(paradigm === "fr" || paradigm === "pr") && (
+                {(paradigm === "fr" || paradigm === "pr" || paradigm === "fr_lite") && (
                   <>
                     <span className="text-theme-text/60">Ratio:</span>
                     <span className="font-mono">{session.paradigmSettings.ratio}</span>

--- a/web/src/components/program/ParadigmSettings.tsx
+++ b/web/src/components/program/ParadigmSettings.tsx
@@ -26,7 +26,7 @@ export function ParadigmSettings({ sessionId, paradigm }: Props) {
     <div className="card">
       <h3 className="font-medium text-theme-text">Paradigm Settings — <span className="text-accent">{paradigm.toUpperCase()}</span></h3>
 
-      {(paradigm === "fr" || paradigm === "pr") && (
+      {(paradigm === "fr" || paradigm === "pr" || paradigm === "fr_lite") && (
         <div className="flex items-center gap-2">
           <label className="text-sm w-24 text-theme-text/60">Ratio:</label>
           <input type="number" value={ratio} onChange={(e) => setRatio(+e.target.value)}

--- a/web/src/components/program/presets/frLitePresets.ts
+++ b/web/src/components/program/presets/frLitePresets.ts
@@ -1,0 +1,81 @@
+import type { SessionPreset, PresetDeviceEntry } from "./types";
+import type { HardwareUiState } from "../../../types";
+import {
+  CORE_DEVICES,
+  PUMP_DEVICE,
+  OPTIONAL_DEVICES,
+  CORE_HARDWARE,
+  PUMP_HARDWARE,
+  OPTIONAL_HARDWARE,
+  PARADIGM_SETTINGS,
+} from "./frSaPresets";
+
+/* fr_lite is identical to fr except it has no two-photon hardware
+ * (microscope, SLM) — these presets mirror frSaPresets.ts with those two
+ * devices stripped out. */
+
+const LITE_OPTIONAL_DEVICES: PresetDeviceEntry[] = OPTIONAL_DEVICES.filter(
+  (d) => d.key !== "microscope" && d.key !== "slm"
+);
+
+const { microscope: _microscope, slm: _slm, ...LITE_OPTIONAL_HARDWARE } = OPTIONAL_HARDWARE;
+
+export const SA_HIGH_LITE_PRESET: SessionPreset = {
+  id: "sa-high-lite",
+  name: "Self-Administration - High Day (Lite)",
+  menuLabel: "SA High",
+  paradigm: "fr_lite",
+  devices: [...CORE_DEVICES, PUMP_DEVICE, ...LITE_OPTIONAL_DEVICES],
+  hardware: { ...CORE_HARDWARE, ...PUMP_HARDWARE, ...LITE_OPTIONAL_HARDWARE },
+  paradigmSettings: PARADIGM_SETTINGS,
+  limitDefaults: { limitType: "Both", timeLimit: 3600, infusionLimit: 10, delay: 10 },
+};
+
+export const SA_MID_LITE_PRESET: SessionPreset = {
+  id: "sa-mid-lite",
+  name: "Self-Administration - Mid Day (Lite)",
+  menuLabel: "SA Mid",
+  paradigm: "fr_lite",
+  devices: [...CORE_DEVICES, PUMP_DEVICE, ...LITE_OPTIONAL_DEVICES],
+  hardware: { ...CORE_HARDWARE, ...PUMP_HARDWARE, ...LITE_OPTIONAL_HARDWARE },
+  paradigmSettings: PARADIGM_SETTINGS,
+  limitDefaults: { limitType: "Both", timeLimit: 3600, infusionLimit: 20, delay: 10 },
+};
+
+export const SA_LOW_LITE_PRESET: SessionPreset = {
+  id: "sa-low-lite",
+  name: "Self-Administration - Low Day (Lite)",
+  menuLabel: "SA Low",
+  paradigm: "fr_lite",
+  devices: [...CORE_DEVICES, PUMP_DEVICE, ...LITE_OPTIONAL_DEVICES],
+  hardware: { ...CORE_HARDWARE, ...PUMP_HARDWARE, ...LITE_OPTIONAL_HARDWARE },
+  paradigmSettings: PARADIGM_SETTINGS,
+  limitDefaults: { limitType: "Both", timeLimit: 3600, infusionLimit: 40, delay: 10 },
+};
+
+const EXTINCTION_LITE_DEVICES: PresetDeviceEntry[] = [
+  { key: "rhLever",     label: "RH Lever", role: "Active lever — tracked but no reward", required: true },
+  { key: "lhLever",     label: "LH Lever", role: "Inactive lever — tracking only",       required: true },
+  { key: "primaryCue",  label: "Cue 1",    role: "Disabled during extinction",           required: false },
+  { key: "primaryPump", label: "Pump 1",   role: "Disabled during extinction",           required: false },
+  ...LITE_OPTIONAL_DEVICES,
+];
+
+export const SA_EXTINCTION_LITE_PRESET: SessionPreset = {
+  id: "sa-extinction-lite",
+  name: "Self-Administration - Extinction (Lite)",
+  menuLabel: "SA Extinction",
+  paradigm: "fr_lite",
+  devices: EXTINCTION_LITE_DEVICES,
+  hardware: {
+    rhLever: { armed: true, timeout: 20000, ratio: 1 },
+    lhLever: { armed: true, timeout: 20000, ratio: 1 },
+    primaryCue:  { armed: false, frequency: 8000, duration: 1600,
+      contingency: { leverFilter: "none", delay: 0 } },
+    primaryPump: { armed: false, duration: 2000,
+      contingency: { leverFilter: "none", delay: 1600 } },
+    ...LITE_OPTIONAL_HARDWARE,
+  } as Partial<HardwareUiState>,
+  paradigmSettings: PARADIGM_SETTINGS,
+  limitDefaults: { limitType: "Time", timeLimit: 3600, infusionLimit: 30, delay: 10 },
+};

--- a/web/src/components/program/presets/frSaPresets.ts
+++ b/web/src/components/program/presets/frSaPresets.ts
@@ -3,17 +3,17 @@ import type { HardwareUiState } from "../../../types";
 
 /* ── Shared device entries ─────────────────────────────────────────── */
 
-const CORE_DEVICES: PresetDeviceEntry[] = [
+export const CORE_DEVICES: PresetDeviceEntry[] = [
   { key: "rhLever",    label: "RH Lever", role: "Active lever — triggers reward chain", required: true },
   { key: "lhLever",    label: "LH Lever", role: "Inactive lever — tracking only",       required: true },
   { key: "primaryCue", label: "Cue 1",    role: "Tone cue — signals reward",            required: true },
 ];
 
-const PUMP_DEVICE: PresetDeviceEntry = {
+export const PUMP_DEVICE: PresetDeviceEntry = {
   key: "primaryPump", label: "Pump 1", role: "Syringe pump — delivers infusion", required: true,
 };
 
-const OPTIONAL_DEVICES: PresetDeviceEntry[] = [
+export const OPTIONAL_DEVICES: PresetDeviceEntry[] = [
   { key: "laser",       label: "Laser",       role: "Optogenetic stimulus — paired with pump", required: false },
   { key: "lickCircuit", label: "Lick Circuit", role: "Lick detection — user-enabled",          required: false },
   { key: "microscope",  label: "Microscope",   role: "Imaging sync — user-enabled",            required: false },
@@ -22,19 +22,19 @@ const OPTIONAL_DEVICES: PresetDeviceEntry[] = [
 
 /* ── Shared hardware settings ──────────────────────────────────────── */
 
-const CORE_HARDWARE: Partial<HardwareUiState> = {
+export const CORE_HARDWARE: Partial<HardwareUiState> = {
   rhLever:    { armed: true,  timeout: 20000, ratio: 1 },
   lhLever:    { armed: true,  timeout: 20000, ratio: 1 },
   primaryCue: { armed: true,  frequency: 8000, duration: 1600,
     contingency: { leverFilter: "rh", delay: 0 } },
 };
 
-const PUMP_HARDWARE: Partial<HardwareUiState> = {
+export const PUMP_HARDWARE: Partial<HardwareUiState> = {
   primaryPump: { armed: true, duration: 2000,
     contingency: { leverFilter: "rh", delay: 1600 } },
 };
 
-const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
+export const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
   laser:        { armed: false, frequency: 40, duration: 5000, mode: "contingent" as const, contingency: "any" as const, onsetDelay: 0 },
   lickCircuit:  { armed: false },
   microscope:   { armed: false, frameRate: null, frameAveraging: null },
@@ -47,7 +47,7 @@ const OPTIONAL_HARDWARE: Partial<HardwareUiState> = {
 
 /* ── Shared paradigm settings ──────────────────────────────────────── */
 
-const PARADIGM_SETTINGS: SessionPreset["paradigmSettings"] = {
+export const PARADIGM_SETTINGS: SessionPreset["paradigmSettings"] = {
   ratio: 1,
   step: 1,
   interval: 30000,

--- a/web/src/components/program/presets/index.ts
+++ b/web/src/components/program/presets/index.ts
@@ -1,6 +1,7 @@
 export type { SessionPreset, PresetDeviceEntry } from "./types";
 export { FR1FlowDiagram } from "./FR1FlowDiagram";
 export { SA_HIGH_PRESET, SA_MID_PRESET, SA_LOW_PRESET, SA_EXTINCTION_PRESET } from "./frSaPresets";
+export { SA_HIGH_LITE_PRESET, SA_MID_LITE_PRESET, SA_LOW_LITE_PRESET, SA_EXTINCTION_LITE_PRESET } from "./frLitePresets";
 export { PAV_ACQUISITION_PRESET, PAV_REVERSAL_PRESET } from "./pavlovianPresets";
 export { SessionPresetCard } from "./SessionPresetCard";
 export { buildPresetFromSession } from "./deviceMetadata";
@@ -8,6 +9,7 @@ export { SavePresetDialog } from "./SavePresetDialog";
 export { PresetActionMenu } from "./PresetActionMenu";
 
 import { SA_HIGH_PRESET, SA_MID_PRESET, SA_LOW_PRESET, SA_EXTINCTION_PRESET } from "./frSaPresets";
+import { SA_HIGH_LITE_PRESET, SA_MID_LITE_PRESET, SA_LOW_LITE_PRESET, SA_EXTINCTION_LITE_PRESET } from "./frLitePresets";
 import { PAV_ACQUISITION_PRESET, PAV_REVERSAL_PRESET } from "./pavlovianPresets";
 import type { SessionPreset } from "./types";
 
@@ -16,6 +18,10 @@ export const SESSION_PRESETS: SessionPreset[] = [
   SA_MID_PRESET,
   SA_LOW_PRESET,
   SA_EXTINCTION_PRESET,
+  SA_HIGH_LITE_PRESET,
+  SA_MID_LITE_PRESET,
+  SA_LOW_LITE_PRESET,
+  SA_EXTINCTION_LITE_PRESET,
   PAV_ACQUISITION_PRESET,
   PAV_REVERSAL_PRESET,
 ];


### PR DESCRIPTION
## Summary
- New `presets/frLitePresets.ts`: mirrors `frSaPresets.ts` (4 tiers: High/Mid/Low/Extinction) with `paradigm: "fr_lite"` and microscope/SLM stripped from devices + hardware; wired into `SESSION_PRESETS`.
- Extends the `paradigm === "fr"` ratio-visibility/send checks in `ParadigmSettings.tsx`, `LeverControl.tsx`, and `SessionStartModal.tsx` (x2) to also match `fr_lite`.
- `ParadigmFlowDiagram.tsx`: `fr_lite` now renders the same FR trial timeline as `fr` instead of silently rendering nothing.
- `mock.ts`: demo-mode `listParadigms` now mirrors the real backend's board-aware UNO-to-lite-only filtering instead of a static list.

Closes #107. Depends on the companion backend fix: Otis-Lab-MUSC/reacher#53 (fr_lite sessions aren't functional without it).

## Test plan
- [x] `tsc -b && vite build` — clean
- [ ] Manual: upload fr_lite to a UNO (or simulator), open Session Configuration, confirm the Session Preset dropdown shows the 4 lite presets, applying one arms everything except microscope/SLM, and the Ratio control works
- [ ] Manual: confirm MEGA-detected sessions still show the normal 5 paradigms