### PR TITLE
feat: Add in-app issue reporter with a bundled local GGUF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ web/dist/
 build/
 dist/
 .avrdude-dist/
+.llm-dist/
 *.egg-info/
 __pycache__/
 .venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ python build.py --skip-frontend           # Reuse existing web/dist/
 python build.py --avrdude /usr/bin/avrdude  # Bundle a specific avrdude binary
 python build.py --cli                     # GUI + standalone LabrynthCLI console bundle
 python build.py --cli-only                # Only LabrynthCLI (skips frontend; ships no static/)
+python build.py --skip-llm                # GUI build without llama.cpp + GGUF (~1.1 GB)
 ```
 
 Building the CLI bundle needs the `[cli]` extras importable (`pip install -e ".[cli]"`).
@@ -54,7 +55,7 @@ The CLI bundle (`labrynth-cli.spec` → `dist/LabrynthCLI/`) is a `console=True`
 build for headless hosts; it omits the React frontend and, when frozen, re-spawns itself
 as the reacher backend via the `REACHER_RUN_BACKEND` trampoline in `cli/__main__.py`.
 
-Build pipeline: (0) validate env (reacher install + its bundled firmware hex) → (1) `npm ci && npm run build` → (2) verify assets → (3) PyInstaller. Firmware hex is sourced from the installed `reacher` package (`reacher/hex/<board>/`) — no compile or fetch step. **Output: `dist/Labrynth/` (Linux/Windows) or `dist/Labrynth.app` (macOS).**
+Build pipeline: (0) validate env (reacher install + its bundled firmware hex) → (1) `npm ci && npm run build` → (2) verify assets → (2b) download pinned llama.cpp + GGUF (GUI only; `--skip-llm` skips) → (3) PyInstaller. Firmware hex is sourced from the installed `reacher` package (`reacher/hex/<board>/`) — no compile or fetch step. **Output: `dist/Labrynth/` (Linux/Windows) or `dist/Labrynth.app` (macOS).** The GUI bundle also ships `_MEIPASS/llm/` (`llama-cli` + Qwen2.5-1.5B-Instruct Q4_K_M). The CLI bundle does not. See [docs/issue-reporting.md](docs/issue-reporting.md).
 
 ### Versioning
 
@@ -109,7 +110,7 @@ Machine discovery uses mDNS (polled by `useMachineStore.startDiscoveryPolling`).
 ### Frontend (`web/src/`)
 
 - **`api/`** — `client.ts` (`MachineApiClient`, all REST), `websocket.ts` (auto-reconnecting `ReacherWebSocket`), `sessionClient.ts` (session-scoped helpers), `demoClient.ts` + `mock.ts` (demo-mode fakes).
-- **`store/`** — Zustand stores: `useSessionStore` (sessions Map, events, counters, draft sessions), `useMachineStore` (machines + discovery + per-machine `MachineApiClient` cache outside Zustand state), `useThemeStore`, `useNavigationStore` (active panel: `session | configuration | monitor | data`), `useLogStore`, `useTutorialStore` (also owns `demoMode`), `useUserPresetStore`.
+- **`store/`** — Zustand stores: `useSessionStore` (sessions Map, events, counters, draft sessions), `useMachineStore` (machines + discovery + per-machine `MachineApiClient` cache outside Zustand state), `useThemeStore`, `useNavigationStore` (active panel: `session | configuration | monitor | data`), `useLogStore`, `useTutorialStore` (also owns `demoMode`), `useUserPresetStore`, `useReportStore` (About / error-boundary issue reporter).
 - **`hooks/useSessionWebSockets.ts`** — central WS router: opens one `ReacherWebSocket` per non-draft session, dispatches all incoming message types (`event | frame | config | log | error | upload_progress | session_state | disconnect | export_failed | kernel_error | split | restart`) to the appropriate stores. Skips draft sessions and demo-prefixed IDs. Recovers missed events on reconnect via `client.getBehavior(sessionId)`.
 - **`hooks/useSingleTab.ts`** — enforces single-tab usage (other tabs see a blocked screen).
 - **`logging/`** — always-on diagnostic capture shipped to the backend's
@@ -125,7 +126,11 @@ Machine discovery uses mDNS (polled by `useMachineStore.startDiscoveryPolling`).
   tees into it, so the in-app terminal keeps working and also becomes durable.
   Field values are logged **verbatim** (deliberate — it is what makes bugs
   reproducible); only credential-shaped keys are redacted, and the server
-  re-redacts on ingest. See `docs/logging.md` in the reacher repo.
+  re-redacts on ingest. See `docs/logging.md` in the reacher repo. About →
+  *Report an issue* flushes the buffer, POSTs `/api/issues/report` (reacher),
+  and a bundled local GGUF summarizes the description + a log excerpt into a
+  GitHub issue when `REACHER_GITHUB_TOKEN` is set. Operator setup:
+  [docs/issue-reporting.md](docs/issue-reporting.md).
 - **`components/`** — feature-area folders: `session/`, `configuration/`, `monitor/`, `data/`, `hardware/`, `program/`, `machines/`, `terminal/`, `layout/`, `tutorial/`.
 - **`themes/`** — 5 named themes (`reacher`, `terminal`, `neural`, `midnight`, `ember`), each with a `dark` and `light` palette plus background, font, radius, glass tokens. Theme is applied by writing CSS variables on `:root` (no Tailwind dark-mode toggle alone — `apply()` in `useThemeStore` sets `--color-*`, `--font-*`, etc.). Default: `reacher`. Persistence: `localStorage["labrynth-mode"]`.
 - **`types/index.ts`** — shared TypeScript interfaces (`Session`, `Machine`, `BehaviorEvent`, `FirmwareConfig`, …).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd labrynth
 pip install -e ".[cli]"
 ```
 
-Reference documentation lives in [`docs/`](docs/); [CONTRIBUTING.md](CONTRIBUTING.md) covers the branching and versioning workflow, and [RELEASING.md](RELEASING.md) covers release channels and tagging.
+Reference documentation lives in [`docs/`](docs/) ([issue reporting](docs/issue-reporting.md)); [CONTRIBUTING.md](CONTRIBUTING.md) covers the branching and versioning workflow, and [RELEASING.md](RELEASING.md) covers release channels and tagging.
 
 ---
 

--- a/build.py
+++ b/build.py
@@ -18,6 +18,7 @@ Usage:
   python build.py                          # full GUI build
   python build.py --skip-frontend          # skip npm build
   python build.py --avrdude /usr/bin/avrdude  # explicit avrdude path
+  python build.py --skip-llm               # skip llama.cpp + GGUF (faster local GUI builds)
   python build.py --cli                    # build GUI + LabrynthCLI console app
   python build.py --cli-only               # build only LabrynthCLI (no frontend)
 
@@ -33,7 +34,9 @@ import platform
 import shutil
 import subprocess
 import sys
+import tarfile
 import urllib.request
+import zipfile
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -271,6 +274,171 @@ def _ensure_real_avrdude(avrdude_path):
     return avrdude_path
 
 
+# ---------------------------------------------------------------------------
+# Bundled local LLM (llama.cpp + Qwen2.5-1.5B-Instruct Q4_K_M)
+# ---------------------------------------------------------------------------
+
+_LLAMA_CPP_TAG = "b10622"
+_GGUF_NAME = "qwen2.5-1.5b-instruct-q4_k_m.gguf"
+_GGUF_URL = (
+    "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/"
+    + _GGUF_NAME
+)
+_GGUF_SHA256 = "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e"
+
+# SHA-256 of the official llama.cpp CPU archives for this tag.
+_LLAMA_ARCHIVE_SHA256 = {
+    "llama-b10622-bin-ubuntu-x64.tar.gz": "6cc895c67bfa868faccda8aca06ec136e489609fc20f068550214f149d94fb4c",
+    "llama-b10622-bin-ubuntu-arm64.tar.gz": "6730946e555d57cdd29ad28f9d445a9195fa3d72d5ed076fa6dcfe25a4f4c266",
+    "llama-b10622-bin-macos-arm64.tar.gz": "c0116ec9957477a9c77e68d3cf31e79f9aede1a9210861c7c09d74acc3e9c3cf",
+    "llama-b10622-bin-macos-x64.tar.gz": "b772320b22bc5cf845930088c985012b94e284242c2ad05fad174297eb5e373e",
+    "llama-b10622-bin-win-cpu-x64.zip": "0f016b001d00a0cc25b955a5ae5eb3ce57a0b16adaa9142f8a3c3269e83fce0a",
+    "llama-b10622-bin-win-cpu-arm64.zip": "fba77e5b089bf6ac669a06559c48863c84eda77c4f8678d39861b77407648850",
+}
+
+
+def _llm_platform_archive():
+    """Return (archive_name, is_zip) for the current OS/arch, or None."""
+    system = platform.system()
+    machine = platform.machine().lower()
+    arm = machine in ("arm64", "aarch64")
+    tag = _LLAMA_CPP_TAG
+    if system == "Windows":
+        name = f"llama-{tag}-bin-win-cpu-{'arm64' if arm else 'x64'}.zip"
+        return name, True
+    if system == "Darwin":
+        name = f"llama-{tag}-bin-macos-{'arm64' if arm else 'x64'}.tar.gz"
+        return name, False
+    # Linux (and other Unix) — official builds are Ubuntu glibc.
+    name = f"llama-{tag}-bin-ubuntu-{'arm64' if arm else 'x64'}.tar.gz"
+    return name, False
+
+
+def _download(url, dest):
+    """Download *url* to *dest* with a UA HuggingFace will accept."""
+    req = urllib.request.Request(url, headers={"User-Agent": "labrynth-build"})
+    with urllib.request.urlopen(req, timeout=600) as src, open(dest, "wb") as out:
+        shutil.copyfileobj(src, out)
+
+
+def _safe_extract_tar(tf, dest):
+    """Extract a TarFile to dest, rejecting members that escape dest."""
+    dest_abs = os.path.abspath(dest)
+    for member in tf.getmembers():
+        target = os.path.abspath(os.path.join(dest_abs, member.name))
+        if target != dest_abs and not target.startswith(dest_abs + os.sep):
+            raise RuntimeError(f"unsafe path in archive: {member.name!r}")
+    tf.extractall(dest)
+
+
+def _find_llama_cli(root):
+    """Return the path to llama-cli / llama-cli.exe under *root*, or None."""
+    wanted = {"llama-cli", "llama-cli.exe"}
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            if name in wanted or name.lower() in wanted:
+                path = os.path.join(dirpath, name)
+                if os.path.isfile(path) and os.path.getsize(path) >= 10_000:
+                    return path
+    return None
+
+
+def _copy_llama_runtime(cli_path, dest_dir):
+    """Copy llama-cli and sibling shared libraries into dest_dir."""
+    os.makedirs(dest_dir, exist_ok=True)
+    src_dir = os.path.dirname(cli_path)
+    dest_cli = os.path.join(dest_dir, os.path.basename(cli_path))
+    shutil.copy2(cli_path, dest_cli)
+    os.chmod(dest_cli, 0o755)
+    for name in os.listdir(src_dir):
+        if name.lower().endswith((".dll", ".so", ".dylib")):
+            shutil.copy2(os.path.join(src_dir, name), os.path.join(dest_dir, name))
+    return dest_cli
+
+
+def ensure_llm(skip=False):
+    """Return (llama-cli path, GGUF path), downloading pinned artifacts if needed.
+
+    Returns (None, None) when *skip* is True.  Exits the process if a required
+    download or checksum fails — the GUI bundle is supposed to ship the model.
+    """
+    if skip:
+        return None, None
+
+    dist_dir = os.path.join(PROJECT_ROOT, ".llm-dist")
+    os.makedirs(dist_dir, exist_ok=True)
+
+    gguf_path = os.path.join(dist_dir, _GGUF_NAME)
+    if os.path.isfile(gguf_path) and _sha256_file(gguf_path) == _GGUF_SHA256:
+        print(f"  [OK] Cached GGUF: {gguf_path}")
+    else:
+        print(f"  [INFO] Downloading {_GGUF_NAME} (~1.1 GB)")
+        tmp = gguf_path + ".part"
+        try:
+            _download(_GGUF_URL, tmp)
+        except Exception as exc:
+            print(f"  [ERROR] Failed to download GGUF: {exc}")
+            sys.exit(1)
+        actual = _sha256_file(tmp)
+        if actual != _GGUF_SHA256:
+            os.remove(tmp)
+            print(f"  [ERROR] GGUF checksum mismatch — refusing to bundle. expected={_GGUF_SHA256} actual={actual}")
+            sys.exit(1)
+        os.replace(tmp, gguf_path)
+        print(f"  [OK] Verified GGUF SHA-256: {actual}")
+
+    archive_name, is_zip = _llm_platform_archive()
+    expected = _LLAMA_ARCHIVE_SHA256.get(archive_name)
+    if not expected:
+        print(f"  [ERROR] No pinned SHA-256 for {archive_name}")
+        sys.exit(1)
+
+    plat_key = archive_name.replace(f"llama-{_LLAMA_CPP_TAG}-bin-", "").rsplit(".", 1)[0]
+    runtime_dir = os.path.join(dist_dir, plat_key)
+    cached_cli = _find_llama_cli(runtime_dir) if os.path.isdir(runtime_dir) else None
+    if cached_cli:
+        print(f"  [OK] Cached llama-cli: {cached_cli}")
+        return cached_cli, gguf_path
+
+    archive_path = os.path.join(dist_dir, archive_name)
+    url = f"https://github.com/ggml-org/llama.cpp/releases/download/{_LLAMA_CPP_TAG}/{archive_name}"
+    print(f"  [INFO] Downloading llama.cpp {_LLAMA_CPP_TAG}: {archive_name}")
+    try:
+        _download(url, archive_path)
+    except Exception as exc:
+        print(f"  [ERROR] Failed to download llama.cpp: {exc}")
+        sys.exit(1)
+    actual = _sha256_file(archive_path)
+    if actual != expected:
+        os.remove(archive_path)
+        print(f"  [ERROR] llama.cpp checksum mismatch — refusing to bundle. expected={expected} actual={actual}")
+        sys.exit(1)
+    print(f"  [OK] Verified llama.cpp SHA-256: {actual}")
+
+    extract_dir = os.path.join(dist_dir, f"_extract-{plat_key}")
+    if os.path.isdir(extract_dir):
+        shutil.rmtree(extract_dir)
+    os.makedirs(extract_dir)
+    try:
+        if is_zip:
+            with zipfile.ZipFile(archive_path) as zf:
+                _safe_extract(zf, extract_dir)
+        else:
+            with tarfile.open(archive_path, "r:gz") as tf:
+                _safe_extract_tar(tf, extract_dir)
+    except Exception as exc:
+        print(f"  [ERROR] Failed to extract llama.cpp archive: {exc}")
+        sys.exit(1)
+
+    found = _find_llama_cli(extract_dir)
+    if not found:
+        print("  [ERROR] llama-cli not found in downloaded archive")
+        sys.exit(1)
+    cli_path = _copy_llama_runtime(found, runtime_dir)
+    print(f"  [OK] llama-cli: {cli_path}")
+    return cli_path, gguf_path
+
+
 def validate_assets(avrdude_path, require_frontend=True):
     """Validate that all required assets exist before packaging."""
     print("\n=== Stage 2: Validate assets ===")
@@ -324,7 +492,7 @@ def validate_assets(avrdude_path, require_frontend=True):
     return avrdude_path
 
 
-def run_pyinstaller(avrdude_path, spec_file=SPEC_FILE):
+def run_pyinstaller(avrdude_path, spec_file=SPEC_FILE, llm_bin=None, llm_model=None):
     """Run PyInstaller with the given spec file."""
     print(f"\n=== Stage 3: Run PyInstaller ({os.path.basename(spec_file)}) ===")
     if not shutil.which("pyinstaller"):
@@ -334,6 +502,10 @@ def run_pyinstaller(avrdude_path, spec_file=SPEC_FILE):
     env = os.environ.copy()
     if avrdude_path:
         env["REACHER_AVRDUDE_PATH"] = avrdude_path
+    if llm_bin:
+        env["REACHER_LLM_BIN"] = llm_bin
+    if llm_model:
+        env["REACHER_LLM_MODEL"] = llm_model
 
     _run(
         ["pyinstaller", "--noconfirm", "--clean", spec_file],
@@ -403,6 +575,11 @@ def main():
         action="store_true",
         help="Build only LabrynthCLI (no frontend, no GUI bundle)",
     )
+    parser.add_argument(
+        "--skip-llm",
+        action="store_true",
+        help="Skip downloading/bundling llama.cpp + GGUF (GUI builds only; issue reporting will be unavailable)",
+    )
     args = parser.parse_args()
 
     print("Labrynth Build Orchestrator")
@@ -415,7 +592,7 @@ def main():
     if args.cli or args.cli_only:
         validate_cli_deps()
 
-    # CLI-only: skip frontend entirely; the CLI bundle ships no static/.
+    # CLI-only: skip frontend entirely; the CLI bundle ships no static/ and no LLM.
     if args.cli_only:
         avrdude_path = validate_assets(args.avrdude, require_frontend=False)
         run_pyinstaller(avrdude_path, SPEC_FILE_CLI)
@@ -431,13 +608,21 @@ def main():
     # Stage 2: Validate
     avrdude_path = validate_assets(args.avrdude)
 
+    print("\n=== Stage 2b: Local LLM (llama.cpp + GGUF) ===")
+    llm_bin, llm_model = ensure_llm(skip=args.skip_llm)
+    if args.skip_llm:
+        print("  [SKIP] llama.cpp / GGUF not bundled (--skip-llm)")
+    elif llm_bin:
+        print(f"  [OK] llama-cli: {llm_bin}")
+        print(f"  [OK] GGUF:      {llm_model}")
+
     # Stage 3: PyInstaller (GUI)
-    run_pyinstaller(avrdude_path)
+    run_pyinstaller(avrdude_path, llm_bin=llm_bin, llm_model=llm_model)
 
     # Stage 4: Report (GUI)
     report_output()
 
-    # Optional: also build the standalone CLI bundle
+    # Optional: also build the standalone CLI bundle (no LLM)
     if args.cli:
         run_pyinstaller(avrdude_path, SPEC_FILE_CLI)
         report_output("LabrynthCLI")

--- a/docs/issue-reporting.md
+++ b/docs/issue-reporting.md
@@ -1,0 +1,71 @@
+# In-app issue reporting
+
+Labrynth can turn a researcher’s plain-language description plus a compact
+slice of the current diagnostic run log into a structured GitHub issue. The
+summarizer is a bundled `llama.cpp` binary and a Qwen2.5-1.5B GGUF — there is
+no cloud LLM key. Filing the issue on GitHub is optional and **operator
+configured**.
+
+## Operator setup (lab machines)
+
+Set these on each rig that should file issues. They are **not** baked into the
+installer.
+
+```bash
+export REACHER_GITHUB_TOKEN=github_pat_...   # fine-grained PAT
+export REACHER_GITHUB_OWNER=Otis-Lab-MUSC    # optional; this is the default
+```
+
+Token scopes:
+
+- Resource: `Otis-Lab-MUSC/labrynth` and `Otis-Lab-MUSC/reacher`
+- Permission: **Issues: Read and write** (enough to create issues and labels)
+
+On Windows, set the same variables in the user or system environment, or in
+whatever wrapper starts Labrynth.
+
+If the token is unset, About → Report an issue still runs the local model and
+lets the user copy the generated markdown. Submit-to-GitHub is disabled.
+
+The GUI installer sets `REACHER_LLM_BIN` and `REACHER_LLM_MODEL` automatically
+from the frozen `llm/` directory. Dev-from-source builds do not ship the GGUF;
+either point those two variables at a local `llama-cli` + GGUF, or the report
+endpoint returns 503.
+
+## What gets sent to GitHub
+
+A capped excerpt of the current run: process meta (versions, platform), error
+and warning records, recent UI events, and session lifecycle. **Not** the full
+diagnostics ZIP.
+
+Field values in the log are recorded verbatim (subject IDs, doses, paths). The
+report modal discloses this. Treat a filed issue as sensitive as the experiment
+data.
+
+## Backend requirement
+
+`POST /api/issues/report` and `GET /api/issues/status` live in **reacher**.
+Until a reacher release that includes those routes is published to PyPI, run
+Labrynth against an editable install:
+
+```bash
+pip install -e ../reacher
+```
+
+Then, after that reacher version is on PyPI, pin it here with:
+
+```bash
+python scripts/bump-version.py --reacher-pin <reacher-semver>
+```
+
+Do not hand-edit `pyproject.toml`.
+
+## Installer notes
+
+`python build.py` downloads a pinned llama.cpp CPU archive and the Qwen2.5-1.5B
+Q4_K_M GGUF into `.llm-dist/` (SHA-256 verified) and copies them into the GUI
+bundle. Use `--skip-llm` for a fast local GUI build without the ~1.1 GB model.
+`build.py --cli-only` never bundles the LLM.
+
+GitHub release assets must stay under 2 GB; the 1.5B Q4 model is the size
+ceiling for that reason.

--- a/labrynth.spec
+++ b/labrynth.spec
@@ -6,6 +6,7 @@ Bundles:
   - Built React frontend  → _MEIPASS/static/
   - Pre-compiled firmware  → _MEIPASS/hex/
   - Platform avrdude       → _MEIPASS/avrdude/
+  - llama.cpp + GGUF       → _MEIPASS/llm/  (GUI only)
 
 Build:
   pyinstaller labrynth.spec
@@ -35,6 +36,10 @@ HEX_DIR = resolve_reacher_hex_dir()
 
 # avrdude — default platform location; override via build.py --avrdude
 AVRDUDE_PATH = os.environ.get("REACHER_AVRDUDE_PATH", "")
+
+# llama.cpp + GGUF — set by build.py (GUI spec only; CLI spec never reads these)
+LLM_BIN = os.environ.get("REACHER_LLM_BIN", "")
+LLM_MODEL = os.environ.get("REACHER_LLM_MODEL", "")
 
 # ---------------------------------------------------------------------------
 # Data files to bundle
@@ -84,6 +89,22 @@ if AVRDUDE_PATH and os.path.isfile(AVRDUDE_PATH):
 else:
     extra_binaries = []
     print("NOTE: No avrdude binary bundled (set REACHER_AVRDUDE_PATH or use build.py --avrdude)")
+
+# llama-cli + companion libs → llm/; GGUF as data in the same folder
+if LLM_BIN and os.path.isfile(LLM_BIN):
+    extra_binaries.append((LLM_BIN, "llm"))
+    _llm_dir = os.path.dirname(LLM_BIN)
+    for _f in os.listdir(_llm_dir):
+        _fpath = os.path.join(_llm_dir, _f)
+        if os.path.isfile(_fpath) and _f.lower().endswith((".dll", ".so", ".dylib")):
+            extra_binaries.append((_fpath, "llm"))
+else:
+    print("NOTE: No llama-cli bundled (set REACHER_LLM_BIN or omit --skip-llm)")
+
+if LLM_MODEL and os.path.isfile(LLM_MODEL):
+    datas.append((LLM_MODEL, "llm"))
+else:
+    print("NOTE: No GGUF bundled (set REACHER_LLM_MODEL or omit --skip-llm)")
 
 # ---------------------------------------------------------------------------
 # Hidden imports — uvicorn internals that PyInstaller cannot detect

--- a/launcher.py
+++ b/launcher.py
@@ -19,6 +19,30 @@ else:
 if os.path.isdir(_STATIC_DIR) and not os.environ.get("REACHER_STATIC_DIR"):
     os.environ["REACHER_STATIC_DIR"] = _STATIC_DIR
 
+# Frozen GUI builds ship llama-cli + GGUF under _MEIPASS/llm/.  Point the
+# reacher report endpoint at them unless the operator overrode the env.
+if hasattr(sys, "_MEIPASS"):
+    _llm_dir = os.path.join(sys._MEIPASS, "llm")
+    if os.path.isdir(_llm_dir):
+        os.environ["PATH"] = _llm_dir + os.pathsep + os.environ.get("PATH", "")
+        if sys.platform == "linux":
+            os.environ["LD_LIBRARY_PATH"] = (
+                _llm_dir + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
+            )
+        elif sys.platform == "darwin":
+            os.environ["DYLD_LIBRARY_PATH"] = (
+                _llm_dir + os.pathsep + os.environ.get("DYLD_LIBRARY_PATH", "")
+            )
+        _exe = "llama-cli.exe" if sys.platform == "win32" else "llama-cli"
+        _bin = os.path.join(_llm_dir, _exe)
+        if os.path.isfile(_bin) and not os.environ.get("REACHER_LLM_BIN"):
+            os.environ["REACHER_LLM_BIN"] = _bin
+        if not os.environ.get("REACHER_LLM_MODEL"):
+            for _name in os.listdir(_llm_dir):
+                if _name.endswith(".gguf"):
+                    os.environ["REACHER_LLM_MODEL"] = os.path.join(_llm_dir, _name)
+                    break
+
 # Propagate --incognito / -i flag so app.py opens the browser in private mode.
 if "--incognito" in sys.argv or "-i" in sys.argv:
     os.environ["REACHER_INCOGNITO"] = "1"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import { useIdleTimer } from "./hooks/useIdleTimer";
 import { useSingleTab } from "./hooks/useSingleTab";
 import { useScrollReveal } from "./hooks/useScrollReveal";
 import { ErrorBoundary } from "./components/layout/ErrorBoundary";
+import { ReportIssueModal } from "./components/layout/ReportIssueModal";
 import type { Panel } from "./store/useNavigationStore";
 
 function BackgroundLayer() {
@@ -121,6 +122,7 @@ function AppContent() {
       <TutorialOverlay />
       <HelpPanel />
       <WelcomeScreen />
+      <ReportIssueModal />
     </div>
   );
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -364,6 +364,30 @@ export class MachineApiClient {
       method: "POST",
       body: JSON.stringify(payload),
     });
+
+  // --- Issues ---
+  getIssueStatus = () =>
+    this.request<{ llm: boolean; github: boolean; owner: string; repos: string[] }>("/issues/status");
+  reportIssue = (body: {
+    description: string;
+    steps?: string;
+    severity?: string;
+    repo?: string;
+    app_version?: string;
+    file?: boolean;
+  }) =>
+    this.request<{
+      title: string;
+      body: string;
+      labels: string[];
+      summarized: boolean;
+      filed: boolean;
+      html_url: string | null;
+      repo: string;
+    }>("/issues/report", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -80,4 +80,46 @@ export class DemoMachineApiClient extends MachineApiClient {
   // --- File ---
   setFileConfig = (id: string, body: { filename?: string; destination?: string }) =>
     mock.setFileConfig(id, body) as ReturnType<MachineApiClient["setFileConfig"]>;
+
+  // --- Issues (never talks to GitHub in demo mode) ---
+  getIssueStatus = async () => ({
+    llm: true,
+    github: false,
+    owner: "Otis-Lab-MUSC",
+    repos: ["labrynth", "reacher"],
+  });
+  reportIssue = async (body: {
+    description: string;
+    steps?: string;
+    severity?: string;
+    repo?: string;
+    app_version?: string;
+    file?: boolean;
+  }) => ({
+    title: body.description.trim().split("\n")[0]?.slice(0, 72) || "Demo issue",
+    body: [
+      "## Description",
+      body.description,
+      "",
+      "## Steps to Reproduce",
+      body.steps?.trim() || "Unknown — needs investigation",
+      "",
+      "## Expected Behavior",
+      "Unknown — needs investigation",
+      "",
+      "## Actual Behavior",
+      "See description.",
+      "",
+      "## Severity",
+      body.severity || "unspecified",
+      "",
+      "## Reporter Notes",
+      "Demo mode — this report was not filed on GitHub.",
+    ].join("\n"),
+    labels: ["bug"],
+    summarized: true,
+    filed: false,
+    html_url: null,
+    repo: body.repo || "labrynth",
+  });
 }

--- a/web/src/components/layout/AboutModal.tsx
+++ b/web/src/components/layout/AboutModal.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Download, ExternalLink, X } from "lucide-react";
+import { Bug, Download, ExternalLink, X } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { useUpdateCheck } from "../../hooks/useUpdateCheck";
 import { useUpdateStore } from "../../store/useUpdateStore";
 import { getLocalClient } from "../../api/client";
 import { downloadDiagnostics } from "../../logging";
+import { useReportStore } from "../../store/useReportStore";
 
 interface AboutModalProps {
   open: boolean;
@@ -141,6 +142,16 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
         )}
 
         <div className="border-t border-theme-border pt-3">
+          <button
+            onClick={() => {
+              onClose();
+              useReportStore.getState().openReport();
+            }}
+            className="mb-2 flex w-full items-center justify-center gap-1.5 rounded border border-theme-border px-3 py-2 text-xs text-theme-text/70 transition hover:border-accent hover:text-accent"
+          >
+            <Bug size={11} />
+            Report an issue
+          </button>
           <button
             onClick={handleDiagnostics}
             disabled={diagBusy}

--- a/web/src/components/layout/ErrorBoundary.tsx
+++ b/web/src/components/layout/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { flush, log } from "../../logging";
+import { useReportStore } from "../../store/useReportStore";
 
 interface Props { children: ReactNode }
 interface State { error: Error | null }
@@ -34,6 +35,18 @@ export class ErrorBoundary extends Component<Props, State> {
               className="mt-4 rounded bg-accent px-4 py-2 text-sm text-white hover:opacity-90"
             >
               Try Again
+            </button>
+            <button
+              onClick={() =>
+                useReportStore.getState().openReport(
+                  this.state.error
+                    ? `The UI crashed: ${this.state.error.message}`
+                    : "The UI crashed.",
+                )
+              }
+              className="mt-2 rounded border border-theme-border px-4 py-2 text-sm text-theme-text hover:border-accent hover:text-accent"
+            >
+              Report this crash
             </button>
           </div>
         </div>

--- a/web/src/components/layout/ReportIssueModal.tsx
+++ b/web/src/components/layout/ReportIssueModal.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Copy, ExternalLink, X } from "lucide-react";
+import { getLocalClient } from "../../api/client";
+import { DemoMachineApiClient } from "../../api/demoClient";
+import { flush, log } from "../../logging";
+import { useReportStore } from "../../store/useReportStore";
+import { useSessionStore } from "../../store/useSessionStore";
+import { LOCAL_PLACEHOLDER_ID, useMachineStore } from "../../store/useMachineStore";
+import { useTutorialStore } from "../../store/useTutorialStore";
+
+type Severity = "" | "minor" | "moderate" | "critical";
+type Repo = "labrynth" | "reacher";
+
+interface IssueStatus {
+  llm: boolean;
+  github: boolean;
+  owner: string;
+  repos: string[];
+}
+
+interface ReportResult {
+  title: string;
+  body: string;
+  labels: string[];
+  summarized: boolean;
+  filed: boolean;
+  html_url: string | null;
+  repo: string;
+}
+
+export function ReportIssueModal() {
+  const open = useReportStore((s) => s.open);
+  const prefill = useReportStore((s) => s.prefill);
+  const closeReport = useReportStore((s) => s.closeReport);
+
+  const [description, setDescription] = useState("");
+  const [steps, setSteps] = useState("");
+  const [severity, setSeverity] = useState<Severity>("");
+  const [repo, setRepo] = useState<Repo>("labrynth");
+  const [status, setStatus] = useState<IssueStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<ReportResult | null>(null);
+  const [copied, setCopied] = useState(false);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const demoMode = useTutorialStore((s) => s.demoMode);
+
+  function apiClient() {
+    if (useTutorialStore.getState().demoMode) {
+      return useMachineStore.getState().getClient(LOCAL_PLACEHOLDER_ID) ?? new DemoMachineApiClient();
+    }
+    return useMachineStore.getState().getClient(LOCAL_PLACEHOLDER_ID) ?? getLocalClient();
+  }
+
+  const sessionRunning = useSessionStore((s) =>
+    [...s.sessions.values()].some((sess) => sess.state === "running"),
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setDescription(prefill);
+    setSteps("");
+    setSeverity("");
+    setRepo("labrynth");
+    setError(null);
+    setResult(null);
+    setCopied(false);
+    closeRef.current?.focus();
+  }, [open, prefill]);
+
+  useEffect(() => {
+    if (!open) return;
+    setStatus(null);
+    apiClient()
+      .getIssueStatus()
+      .then(setStatus)
+      .catch(() =>
+        setStatus({ llm: false, github: false, owner: "Otis-Lab-MUSC", repos: ["labrynth", "reacher"] }),
+      );
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) closeReport();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, busy, closeReport]);
+
+  if (!open) return null;
+
+  const llmReady = Boolean(status?.llm);
+  const githubReady = Boolean(status?.github) && !demoMode;
+  const canSubmit = description.trim().length > 0 && llmReady && !busy;
+
+  async function handleSubmit() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    log("ui.issue_report", { repo, severity, demoMode }, "info", {
+      msg: "Issue report submitted",
+      src: "ReportIssueModal",
+    });
+    try {
+      await flush();
+      const data = await apiClient().reportIssue({
+        description: description.trim(),
+        steps: steps.trim(),
+        severity,
+        repo,
+        app_version: __APP_VERSION__,
+        file: githubReady,
+      });
+      setResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Report failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!result) return;
+    const text = `# ${result.title}\n\n${result.body}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Could not copy to clipboard");
+    }
+  }
+
+  const submitLabel = busy
+    ? "Working…"
+    : githubReady
+      ? "Submit to GitHub"
+      : "Summarize";
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onMouseDown={() => {
+        if (!busy) closeReport();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="report-issue-title"
+        className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border border-theme-border bg-panel p-5 shadow-xl"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h3 id="report-issue-title" className="text-base font-semibold text-theme-text">
+            Report an issue
+          </h3>
+          <button
+            ref={closeRef}
+            onClick={closeReport}
+            disabled={busy}
+            className="rounded p-1 opacity-50 transition hover:bg-accent/10 hover:opacity-100 disabled:opacity-30"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {result ? (
+          <div className="space-y-3">
+            {result.filed && result.html_url ? (
+              <p className="text-sm text-theme-text/80">
+                Filed{" "}
+                <a
+                  href={result.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-accent hover:underline"
+                >
+                  {result.title} <ExternalLink size={12} />
+                </a>
+              </p>
+            ) : (
+              <p className="text-sm text-theme-text/80">
+                {result.summarized
+                  ? "Summary ready. GitHub filing is not configured on this machine — copy the markdown below."
+                  : "The local model could not summarize this report. A fallback draft is below."}
+              </p>
+            )}
+            <pre className="max-h-64 overflow-auto rounded border border-theme-border bg-black/20 p-3 text-xs text-theme-text/80 whitespace-pre-wrap">
+              {`# ${result.title}\n\n${result.body}`}
+            </pre>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={handleCopy}
+                className="flex items-center gap-1.5 rounded border border-theme-border px-3 py-1.5 text-xs text-theme-text/70 transition hover:border-accent hover:text-accent"
+              >
+                <Copy size={11} />
+                {copied ? "Copied" : "Copy markdown"}
+              </button>
+              <button
+                onClick={closeReport}
+                className="rounded bg-accent px-3 py-1.5 text-xs text-white hover:opacity-90"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <p className="mb-3 text-xs text-theme-text/60">
+              Describe what happened in your own words. A local model on this machine will turn
+              that description plus a compact slice of this run&apos;s diagnostic log into a
+              technical GitHub issue. No cloud AI key is required.
+            </p>
+            <p className="mb-4 text-xs text-amber-500/90">
+              The log excerpt can include experiment identifiers (subject IDs, doses, file paths).
+              Only submit if you are comfortable sending that excerpt to GitHub.
+            </p>
+
+            <label className="mb-3 block text-xs font-medium text-theme-text/70">
+              What happened?
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={5}
+                className="mt-1 w-full rounded border border-theme-border bg-transparent px-2 py-1.5 text-sm text-theme-text focus:border-accent focus:outline-none"
+                placeholder="e.g. The camera feed froze during the trial and I had to restart…"
+              />
+            </label>
+
+            <label className="mb-3 block text-xs font-medium text-theme-text/70">
+              Steps to reproduce (optional)
+              <textarea
+                value={steps}
+                onChange={(e) => setSteps(e.target.value)}
+                rows={3}
+                className="mt-1 w-full rounded border border-theme-border bg-transparent px-2 py-1.5 text-sm text-theme-text focus:border-accent focus:outline-none"
+                placeholder="1. Started a new session  2. Ran 3 trials  3. …"
+              />
+            </label>
+
+            <div className="mb-3 grid grid-cols-2 gap-3">
+              <label className="block text-xs font-medium text-theme-text/70">
+                How disruptive?
+                <select
+                  value={severity}
+                  onChange={(e) => setSeverity(e.target.value as Severity)}
+                  className="mt-1 w-full rounded border border-theme-border bg-panel px-2 py-1.5 text-sm text-theme-text focus:border-accent focus:outline-none"
+                >
+                  <option value="">Unspecified</option>
+                  <option value="minor">Minor — I could continue</option>
+                  <option value="moderate">Moderate — I had to work around it</option>
+                  <option value="critical">Critical — stopped my work</option>
+                </select>
+              </label>
+              <label className="block text-xs font-medium text-theme-text/70">
+                Repository
+                <select
+                  value={repo}
+                  onChange={(e) => setRepo(e.target.value as Repo)}
+                  className="mt-1 w-full rounded border border-theme-border bg-panel px-2 py-1.5 text-sm text-theme-text focus:border-accent focus:outline-none"
+                >
+                  <option value="labrynth">labrynth (this app)</option>
+                  <option value="reacher">reacher (backend / firmware)</option>
+                </select>
+              </label>
+            </div>
+
+            {sessionRunning && (
+              <p className="mb-3 text-xs text-amber-500/90">
+                A session is running. Summarization uses a small amount of CPU and may take up to
+                two minutes.
+              </p>
+            )}
+
+            {demoMode && (
+              <p className="mb-3 text-xs text-theme-text/50">
+                Demo mode: nothing will be filed on GitHub.
+              </p>
+            )}
+
+            {status && !status.llm && (
+              <p className="mb-3 text-xs text-red-500">
+                The local summarizer is not available on this build. Issue reporting needs the
+                bundled llama.cpp model.
+              </p>
+            )}
+
+            {status && status.llm && !githubReady && !demoMode && (
+              <p className="mb-3 text-xs text-theme-text/50">
+                GitHub filing is not configured (no REACHER_GITHUB_TOKEN). You can still summarize
+                and copy the markdown.
+              </p>
+            )}
+
+            {error && <p className="mb-3 text-xs text-red-500">{error}</p>}
+
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={closeReport}
+                disabled={busy}
+                className="rounded px-3 py-1.5 text-sm text-theme-text hover:bg-accent/10 disabled:opacity-40"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+                className="rounded bg-accent px-3 py-1.5 text-sm text-white hover:opacity-90 disabled:opacity-40"
+              >
+                {submitLabel}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/tutorial/help/content.ts
+++ b/web/src/components/tutorial/help/content.ts
@@ -173,6 +173,12 @@ export const HELP_CONTENT: HelpSection[] = [
           "Set the output filename and destination directory on the Session Configuration page before starting. Click Save Config to persist these to the backend. For a local session, use Browse to pick a folder; for a paired remote machine there's no Browse — type a path on the remote host, where the data lives. If left blank, data defaults to a timestamp-based filename in the session host's ~/Downloads. The engine also streams every event to an append-only on-disk log under ~/REACHER/LOG/ on the host, so raw data survives even if export fails.",
       },
       {
+        id: "data.report",
+        title: "Reporting an issue",
+        content:
+          "About → Report an issue lets you describe a problem in your own words. A local model that ships with Labrynth (no cloud AI key) turns that description plus a compact excerpt of this run's diagnostic log into a technical GitHub issue.\n\nThe excerpt can include experiment identifiers such as subject IDs, doses, and file paths — only submit if you are comfortable sending that to GitHub. When a lab operator has set REACHER_GITHUB_TOKEN on the machine, the issue is filed automatically; otherwise you can copy the generated markdown.\n\nAbout → Download diagnostics still exports the full run ZIP for attaching separately. Demo mode never files a real GitHub issue.",
+      },
+      {
         id: "data.export",
         title: "Auto-Export",
         content:

--- a/web/src/store/useReportStore.ts
+++ b/web/src/store/useReportStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface ReportStore {
+  open: boolean;
+  prefill: string;
+  openReport: (prefill?: string) => void;
+  closeReport: () => void;
+}
+
+export const useReportStore = create<ReportStore>((set) => ({
+  open: false,
+  prefill: "",
+  openReport: (prefill = "") => set({ open: true, prefill }),
+  closeReport: () => set({ open: false }),
+}));


### PR DESCRIPTION
## Summary
- Add About → Report an issue (and a crash-boundary CTA) that flushes diagnostics, runs a bundled local GGUF via reacher's `/api/issues/report`, and files a GitHub issue when a lab token is configured.
- Bundle pinned llama.cpp (`b10622`) + Qwen2.5-1.5B-Instruct Q4_K_M in the GUI installer only (`--skip-llm` / CLI bundle omit it).
- Demo mode never talks to GitHub. Operator setup is in `docs/issue-reporting.md`.

Depends on Otis-Lab-MUSC/reacher#55 (`GET /api/issues/status`, `POST /api/issues/report`). The `reacher2p` pin is unchanged until that reacher release is on PyPI; until then use `pip install -e ../reacher`.

## Test plan
- [ ] `npx tsc -b` in `web/`
- [ ] About → Report an issue: empty description cannot submit; privacy copy is visible
- [ ] Without `REACHER_LLM_BIN`/`REACHER_LLM_MODEL`, status shows the summarizer as unavailable and submit stays disabled
- [ ] Without `REACHER_GITHUB_TOKEN`, summarize still works and returns copyable markdown (`filed: false`)
- [ ] Demo mode / `VITE_DEMO_SITE`: report never hits GitHub
- [ ] Crash screen → Report this crash prefills the description


Made with [Cursor](https://cursor.com)