### PR TITLE
bug: Bundle the shared libraries and llama.cpp binary the summarizer needs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ The CLI bundle (`labrynth-cli.spec` → `dist/LabrynthCLI/`) is a `console=True`
 build for headless hosts; it omits the React frontend and, when frozen, re-spawns itself
 as the reacher backend via the `REACHER_RUN_BACKEND` trampoline in `cli/__main__.py`.
 
-Build pipeline: (0) validate env (reacher install + its bundled firmware hex) → (1) `npm ci && npm run build` → (2) verify assets → (2b) download pinned llama.cpp + GGUF (GUI only; `--skip-llm` skips) → (3) PyInstaller. Firmware hex is sourced from the installed `reacher` package (`reacher/hex/<board>/`) — no compile or fetch step. **Output: `dist/Labrynth/` (Linux/Windows) or `dist/Labrynth.app` (macOS).** The GUI bundle also ships `_MEIPASS/llm/` (`llama-cli` + Qwen2.5-1.5B-Instruct Q4_K_M). The CLI bundle does not. See [docs/issue-reporting.md](docs/issue-reporting.md).
+Build pipeline: (0) validate env (reacher install + its bundled firmware hex) → (1) `npm ci && npm run build` → (2) verify assets → (2b) download pinned llama.cpp + GGUF (GUI only; `--skip-llm` skips) → (3) PyInstaller. Firmware hex is sourced from the installed `reacher` package (`reacher/hex/<board>/`) — no compile or fetch step. **Output: `dist/Labrynth/` (Linux/Windows) or `dist/Labrynth.app` (macOS).** The GUI bundle also ships `_MEIPASS/llm/` (`llama-cli` + `llama-completion` + Qwen2.5-1.5B-Instruct Q4_K_M; `launcher.py` points `REACHER_LLM_BIN` at `llama-completion`, since `llama-cli` is chat-only since b10622). The CLI bundle does not. See [docs/issue-reporting.md](docs/issue-reporting.md).
 
 ### Versioning
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Cross-platform control application for REACHER operant behavior experiments, with a browser interface and a terminal interface over the same rigs.**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.16-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.17-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
 [![Language](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)

--- a/build.py
+++ b/build.py
@@ -31,6 +31,7 @@ import argparse
 import hashlib
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -331,12 +332,33 @@ def _safe_extract_tar(tf, dest):
     tf.extractall(dest)
 
 
+# llama.cpp b10622 split raw prompt completion out of ``llama-cli`` into
+# ``llama-completion``; ``llama-cli`` is chat-only and no longer accepts
+# ``--no-conversation``, which is the flag set reacher's summarizer sends.
+# Bundle both and let the launcher point REACHER_LLM_BIN at the right one.
+_LLAMA_BINARIES = ("llama-cli", "llama-completion")
+
+
+def llama_binaries(root):
+    """Return paths to the llama.cpp executables to bundle, found under *root*."""
+    wanted = {n for b in _LLAMA_BINARIES for n in (b, b + ".exe")}
+    found = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            if name.lower() in wanted:
+                path = os.path.join(dirpath, name)
+                if os.path.isfile(path) and os.path.getsize(path) > 0:
+                    found.append(path)
+    return sorted(found)
+
+
 def _find_llama_cli(root):
     """Return the path to llama-cli / llama-cli.exe under *root*, or None.
 
-    Windows CPU archives ship ``llama-cli.exe`` as a ~9 KB loader stub; the
-    implementation is ``llama-cli-impl.dll`` beside it. A 10 KB size floor
-    rejects that stub and fails the Windows installer build.
+    Any non-empty match is accepted: Windows CPU archives ship
+    ``llama-cli.exe`` as a ~9 KB loader stub whose implementation lives in
+    ``llama-cli-impl.dll`` beside it, so a size floor would reject the real
+    Windows binary.
     """
     wanted = {"llama-cli", "llama-cli.exe"}
     for dirpath, _dirnames, filenames in os.walk(root):
@@ -363,17 +385,59 @@ def _list_llama_cli_candidates(root):
     return found
 
 
+# ELF sonames carry the version *after* the extension (libllama.so.0), so an
+# ``endswith(".so")`` test silently drops exactly the files DT_NEEDED asks for.
+# Mach-O and PE put the version before it (libllama.0.dylib, ggml.dll).
+_SHARED_LIB_RE = re.compile(r"\.(?:dll|dylib)$|\.so(?:\.\d+)*$", re.IGNORECASE)
+
+
+def is_shared_lib(name):
+    """True when *name* is a shared library, including versioned ELF sonames."""
+    return bool(_SHARED_LIB_RE.search(name))
+
+
 def _copy_llama_runtime(cli_path, dest_dir):
-    """Copy llama-cli and sibling shared libraries into dest_dir."""
+    """Copy the llama.cpp executables and sibling shared libraries into dest_dir."""
     os.makedirs(dest_dir, exist_ok=True)
     src_dir = os.path.dirname(cli_path)
     dest_cli = os.path.join(dest_dir, os.path.basename(cli_path))
-    shutil.copy2(cli_path, dest_cli)
-    os.chmod(dest_cli, 0o755)
+    for src in llama_binaries(src_dir):
+        dest = os.path.join(dest_dir, os.path.basename(src))
+        shutil.copy2(src, dest)
+        os.chmod(dest, 0o755)
     for name in os.listdir(src_dir):
-        if name.lower().endswith((".dll", ".so", ".dylib")):
+        if is_shared_lib(name):
             shutil.copy2(os.path.join(src_dir, name), os.path.join(dest_dir, name))
     return dest_cli
+
+
+def _smoke_test_llama(cli_path):
+    """Return (ok, detail) for ``<binary> --version``.
+
+    ``--version`` does not touch the GGUF, so this stays fast and runs before
+    the model is required.  It catches a bundle whose companion libraries are
+    missing or unloadable, which otherwise ships fine and only fails at report
+    time inside reacher's summarizer.
+    """
+    runtime_dir = os.path.dirname(cli_path)
+    env = os.environ.copy()
+    for var in ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"):
+        env[var] = runtime_dir + os.pathsep + env.get(var, "")
+    try:
+        result = subprocess.run(
+            [cli_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+            check=False,
+        )
+    except OSError as exc:
+        return False, str(exc)
+    if result.returncode != 0:
+        detail = ((result.stderr or "") + (result.stdout or "")).strip()
+        return False, f"exit {result.returncode}: {detail[-500:]}"
+    return True, ""
 
 
 def ensure_llm(skip=False):
@@ -417,8 +481,16 @@ def ensure_llm(skip=False):
     runtime_dir = os.path.join(dist_dir, plat_key)
     cached_cli = _find_llama_cli(runtime_dir) if os.path.isdir(runtime_dir) else None
     if cached_cli:
-        print(f"  [OK] Cached llama-cli: {cached_cli}")
-        return cached_cli, gguf_path
+        cached = llama_binaries(runtime_dir)
+        checks = [_smoke_test_llama(b) for b in cached]
+        complete = len(cached) == len(_LLAMA_BINARIES)
+        ok = complete and all(c[0] for c in checks)
+        detail = next((c[1] for c in checks if not c[0]), "incomplete binary set")
+        if ok:
+            print(f"  [OK] Cached llama-cli: {cached_cli}")
+            return cached_cli, gguf_path
+        print(f"  [WARN] Cached llama-cli is not runnable ({detail}); re-extracting")
+        shutil.rmtree(runtime_dir, ignore_errors=True)
 
     archive_path = os.path.join(dist_dir, archive_name)
     url = f"https://github.com/ggml-org/llama.cpp/releases/download/{_LLAMA_CPP_TAG}/{archive_name}"
@@ -457,6 +529,13 @@ def ensure_llm(skip=False):
             print(f"           {size:>10}  {path}")
         sys.exit(1)
     cli_path = _copy_llama_runtime(found, runtime_dir)
+    for _bin in llama_binaries(runtime_dir):
+        ok, detail = _smoke_test_llama(_bin)
+        if not ok:
+            print(f"  [ERROR] Bundled {os.path.basename(_bin)} is not runnable — "
+                  f"refusing to bundle. {detail}")
+            sys.exit(1)
+        print(f"  [OK] {os.path.basename(_bin)} smoke test passed")
     print(f"  [OK] llama-cli: {cli_path} ({os.path.getsize(found)} bytes)")
     return cli_path, gguf_path
 

--- a/docs/issue-reporting.md
+++ b/docs/issue-reporting.md
@@ -29,7 +29,7 @@ lets the user copy the generated markdown. Submit-to-GitHub is disabled.
 
 The GUI installer sets `REACHER_LLM_BIN` and `REACHER_LLM_MODEL` automatically
 from the frozen `llm/` directory. Dev-from-source builds do not ship the GGUF;
-either point those two variables at a local `llama-cli` + GGUF, or the report
+either point those two variables at a local `llama-completion` + GGUF, or the report
 endpoint returns 503.
 
 ## What gets sent to GitHub

--- a/labrynth.spec
+++ b/labrynth.spec
@@ -30,7 +30,7 @@ FRONTEND_DIST = os.path.join(PROJECT_ROOT, "web", "dist")
 # archived). Resolve it via build.py's shared helper so spec and orchestrator
 # agree on the source of truth.
 sys.path.insert(0, SPEC_DIR)
-from build import resolve_reacher_hex_dir  # noqa: E402
+from build import is_shared_lib, llama_binaries, resolve_reacher_hex_dir  # noqa: E402
 
 HEX_DIR = resolve_reacher_hex_dir()
 
@@ -75,7 +75,7 @@ if AVRDUDE_PATH and os.path.isfile(AVRDUDE_PATH):
     # Bundle companion DLLs that live alongside the avrdude binary
     for _f in os.listdir(_avrdude_dir):
         _fpath = os.path.join(_avrdude_dir, _f)
-        if os.path.isfile(_fpath) and _f.lower().endswith((".dll", ".so", ".dylib")):
+        if os.path.isfile(_fpath) and is_shared_lib(_f):
             extra_binaries.append((_fpath, "avrdude"))
 
     # Bundle avrdude.conf as data (not a binary)
@@ -90,16 +90,18 @@ else:
     extra_binaries = []
     print("NOTE: No avrdude binary bundled (set REACHER_AVRDUDE_PATH or use build.py --avrdude)")
 
-# llama-cli + companion libs → llm/; GGUF as data in the same folder
+# llama.cpp executables + companion libs → llm/; GGUF as data in the same folder
 if LLM_BIN and os.path.isfile(LLM_BIN):
-    extra_binaries.append((LLM_BIN, "llm"))
     _llm_dir = os.path.dirname(LLM_BIN)
+    # llama-cli *and* llama-completion — reacher's summarizer runs the latter.
+    for _exe in llama_binaries(_llm_dir):
+        extra_binaries.append((_exe, "llm"))
     for _f in os.listdir(_llm_dir):
         _fpath = os.path.join(_llm_dir, _f)
-        if os.path.isfile(_fpath) and _f.lower().endswith((".dll", ".so", ".dylib")):
+        if os.path.isfile(_fpath) and is_shared_lib(_f):
             extra_binaries.append((_fpath, "llm"))
 else:
-    print("NOTE: No llama-cli bundled (set REACHER_LLM_BIN or omit --skip-llm)")
+    print("NOTE: No llama.cpp binaries bundled (set REACHER_LLM_BIN or omit --skip-llm)")
 
 if LLM_MODEL and os.path.isfile(LLM_MODEL):
     datas.append((LLM_MODEL, "llm"))

--- a/launcher.py
+++ b/launcher.py
@@ -56,13 +56,49 @@ if "--incognito" in sys.argv or "-i" in sys.argv:
 
 if not hasattr(sys, "_MEIPASS"):
     import importlib.util
-    if importlib.util.find_spec("reacher.api") is None:
+    # find_spec raises rather than returning None when the *parent* package is
+    # missing, which is exactly the "reacher not installed" case handled here.
+    try:
+        _have_reacher = importlib.util.find_spec("reacher.api") is not None
+    except ImportError:
+        _have_reacher = False
+    if not _have_reacher:
         print(
             "ERROR: The `reacher` package is not installed. "
             "Run `pip install -e ../reacher` from the labrynth/ directory.",
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # A reacher older than the pin still starts and serves 200s while silently
+    # lacking routers the frontend needs, so surface the mismatch rather than
+    # letting a broken app look like a working one.  Never fatal.
+    try:
+        import re
+
+        def _version_key(v):
+            """Sortable key for semver/PEP 440 prereleases; stable outranks its prereleases."""
+            m = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:-?(alpha|beta|rc|a|b)\.?(\d+))?$", v)
+            if not m:
+                return None
+            _major, _minor, _patch, _kind, _num = m.groups()
+            _stage = {"a": 0, "alpha": 0, "b": 1, "beta": 1, "rc": 2}.get(_kind, 3)
+            return (int(_major), int(_minor), int(_patch), _stage, int(_num or 0))
+
+        with open(os.path.join(_LABRYNTH_ROOT, "pyproject.toml")) as _f:
+            _pin = re.search(r'reacher2p>=([^"]+)"', _f.read()).group(1)
+        import reacher
+        _have, _want = _version_key(reacher.__version__), _version_key(_pin)
+        if _have and _want and _have < _want:
+            print(
+                f"WARNING: reacher {reacher.__version__} is installed but this "
+                f"Labrynth pins reacher2p>={_pin}.\n"
+                "         The frontend may fail against an older backend.\n"
+                "         Run `pip install -e ../reacher` from the labrynth/ directory.",
+                file=sys.stderr,
+            )
+    except Exception:
+        pass
 
 from reacher.api.app import main
 

--- a/launcher.py
+++ b/launcher.py
@@ -33,10 +33,17 @@ if hasattr(sys, "_MEIPASS"):
             os.environ["DYLD_LIBRARY_PATH"] = (
                 _llm_dir + os.pathsep + os.environ.get("DYLD_LIBRARY_PATH", "")
             )
-        _exe = "llama-cli.exe" if sys.platform == "win32" else "llama-cli"
-        _bin = os.path.join(_llm_dir, _exe)
-        if os.path.isfile(_bin) and not os.environ.get("REACHER_LLM_BIN"):
-            os.environ["REACHER_LLM_BIN"] = _bin
+        # reacher's summarizer sends a raw ChatML prompt with --no-conversation.
+        # Since llama.cpp b10622 that is llama-completion; llama-cli is
+        # chat-only and rejects the flag.  Fall back to llama-cli so an older
+        # bundle without llama-completion still resolves to something.
+        _suffix = ".exe" if sys.platform == "win32" else ""
+        if not os.environ.get("REACHER_LLM_BIN"):
+            for _name in ("llama-completion", "llama-cli"):
+                _bin = os.path.join(_llm_dir, _name + _suffix)
+                if os.path.isfile(_bin):
+                    os.environ["REACHER_LLM_BIN"] = _bin
+                    break
         if not os.environ.get("REACHER_LLM_MODEL"):
             for _name in os.listdir(_llm_dir):
                 if _name.endswith(".gguf"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labrynth"
-version = "3.0.1-alpha.16"
+version = "3.0.1-alpha.17"
 description = "Labrynth application shell — build orchestrator and frontend"
 requires-python = ">=3.10"
 dependencies = [
     # PyPI distribution is "reacher2p" (the "reacher" name was taken); the import
     # package is still "reacher" (python -m reacher, importlib hex resolution).
-    "reacher2p>=3.4.0a3",
+    "reacher2p>=3.4.0a4",
     "pyinstaller>=6.0",
 ]
 

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 **Browser-based experiment control interface for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.16-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.17-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
 [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labrynth-frontend",
   "private": true,
-  "version": "3.0.1-alpha.16",
+  "version": "3.0.1-alpha.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -14,7 +14,7 @@ export class DemoMachineApiClient extends MachineApiClient {
 
   // --- Health ---
   probeHealth = async () =>
-    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.16", active_sessions: 0 });
+    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.17", active_sessions: 0 });
 
   // --- Sessions ---
   listSessions = () => mock.listSessions() as ReturnType<MachineApiClient["listSessions"]>;

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -168,7 +168,7 @@ export const uploadFirmware = async (id: string, paradigm: string, board: string
     board,
     firmware_info: {
       sketch: paradigm,
-      version: "3.0.1-alpha.16",
+      version: "3.0.1-alpha.17",
       baud_rate: 115200,
       desc: `Demo ${paradigm.toUpperCase()} firmware`,
     },


### PR DESCRIPTION
## Why

**The bundled LLM has never worked in a shipped Linux build.** Two separate defects stacked, and both were silent because reacher's summarizer falls back to an unsummarized draft rather than failing loudly — so issue reporting looked like it worked while never once producing a model summary.

### 1. Missing shared libraries (Linux only)

`endswith((".dll", ".so", ".dylib"))` does not match a versioned ELF soname. Every Linux bundle dropped ten files — `libllama.so.0`, `libllama-common.so.0`, `libggml.so.0`, `libggml-base.so.0`, `libmtmd.so.0` and their `.0.N.N` targets — which are precisely the `DT_NEEDED` set:

```
$ objdump -p libllama-cli-impl.so | grep NEEDED
  NEEDED  libllama-common.so.0
  NEEDED  libllama.so.0
```

The shipped `llama-cli` exited **127**. PyInstaller reported this in the v3.0.1-alpha.16 build log as a non-fatal warning:

```
WARNING: Library not found: could not resolve 'libllama.so.0',
  dependency of '.../.llm-dist/ubuntu-x64.tar/llama-cli'
```

macOS and Windows were unaffected — they version *before* the extension (`libllama.0.dylib`, `ggml.dll`), so the old filter matched.

### 2. Wrong binary (all platforms)

llama.cpp b10622 split raw prompt completion out of `llama-cli` into `llama-completion`. `llama-cli` is chat-only and rejects `--no-conversation`, which is the flag set reacher sends. Even with the libraries fixed, every report still fell back:

```
llama-cli exited 1: error: invalid argument: --no-conversation
```

## What

- A shared `is_shared_lib()` matching `\.so(\.\d+)*$`, used by **both** `build.py` and `labrynth.spec` so the two cannot disagree. Applied to the avrdude block too — not a live bug there, just the same rule.
- Bundle `llama-cli` **and** `llama-completion`; `launcher.py` points `REACHER_LLM_BIN` at `llama-completion`, falling back to `llama-cli`. Labrynth owns that variable, so **no reacher change was required** for the fix.
- Smoke-test every bundled binary in stage 2b and **fail the build** if one cannot run.
- Validate the `.llm-dist` cache the same way, so a stale broken extract is discarded instead of silently reused.

## Evidence

Predicate against all three real b10622 archives — strict superset, no regression:

| archive | old | new | gained |
|---|---|---|---|
| ubuntu-x64 | 28 | 38 | **+10** |
| macos-arm64 | 35 | 35 | 0 |
| win-cpu-x64 | 29 | 29 | 0 |

Full Linux build, then real inference through `reacher.issues.summarize`:

```
summarized: True | title: Camera feed freezes on session restart | labels: ['bug']   (9.1s)
summarized: True | title: Serial port drops mid-session          | labels: ['bug']
```

The shipped alpha.16 bundle returns `summarized: False` for the same input.

Negative tests: deleting `libllama.so.0` now fails the build (exit 127 caught); a stale cache is re-extracted rather than reused.

`npx tsc -b` clean. Bundle grows **38 MB → 64 MB** (~1.18 GB per asset, against the 2 GB release ceiling).

## Release ordering

Stamped `v3.0.1-alpha.17` and pins `reacher2p>=3.4.0a4`, so `--print-reacher-ref` resolves to `v3.4.0-alpha.4`.

The prerelease workflow does `git clone --branch <ref>` against reacher, so **reacher tag `v3.4.0-alpha.4` must exist before this repo is tagged**. That tag comes from Otis-Lab-MUSC/reacher#56, which adds the liveness probe that would have caught both defects above at `/api/issues/status` instead of in a filed issue.

## Note on commit 2

`chore: Warn when the installed reacher is older than the pin` was pre-existing uncommitted work in the tree, unrelated to the LLM fix. Split into its own commit rather than folded in. Drop it if you'd rather it landed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)