### PR TITLE
bug: Stop adding llm/ to LD_LIBRARY_PATH in frozen builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Cross-platform control application for REACHER operant behavior experiments, with a browser interface and a terminal interface over the same rigs.**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.17-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.18-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
 [![Language](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)

--- a/launcher.py
+++ b/launcher.py
@@ -25,14 +25,11 @@ if hasattr(sys, "_MEIPASS"):
     _llm_dir = os.path.join(sys._MEIPASS, "llm")
     if os.path.isdir(_llm_dir):
         os.environ["PATH"] = _llm_dir + os.pathsep + os.environ.get("PATH", "")
-        if sys.platform == "linux":
-            os.environ["LD_LIBRARY_PATH"] = (
-                _llm_dir + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
-            )
-        elif sys.platform == "darwin":
-            os.environ["DYLD_LIBRARY_PATH"] = (
-                _llm_dir + os.pathsep + os.environ.get("DYLD_LIBRARY_PATH", "")
-            )
+        # Deliberately *not* adding llm/ to LD_LIBRARY_PATH.  Every child of a
+        # frozen build inherits that variable, and pointing it at a directory of
+        # Ubuntu-built libraries breaks unrelated binaries on other distros
+        # (see reacher's child_env).  The llama.cpp binaries carry an $ORIGIN
+        # RPATH, and reacher passes their directory explicitly anyway.
         # reacher's summarizer sends a raw ChatML prompt with --no-conversation.
         # Since llama.cpp b10622 that is llama-completion; llama-cli is
         # chat-only and rejects the flag.  Fall back to llama-cli so an older

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labrynth"
-version = "3.0.1-alpha.17"
+version = "3.0.1-alpha.18"
 description = "Labrynth application shell — build orchestrator and frontend"
 requires-python = ">=3.10"
 dependencies = [
     # PyPI distribution is "reacher2p" (the "reacher" name was taken); the import
     # package is still "reacher" (python -m reacher, importlib hex resolution).
-    "reacher2p>=3.4.0a4",
+    "reacher2p>=3.4.0a5",
     "pyinstaller>=6.0",
 ]
 

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 **Browser-based experiment control interface for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.17-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.18-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
 [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labrynth-frontend",
   "private": true,
-  "version": "3.0.1-alpha.17",
+  "version": "3.0.1-alpha.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -14,7 +14,7 @@ export class DemoMachineApiClient extends MachineApiClient {
 
   // --- Health ---
   probeHealth = async () =>
-    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.17", active_sessions: 0 });
+    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.18", active_sessions: 0 });
 
   // --- Sessions ---
   listSessions = () => mock.listSessions() as ReturnType<MachineApiClient["listSessions"]>;

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -168,7 +168,7 @@ export const uploadFirmware = async (id: string, paradigm: string, board: string
     board,
     firmware_info: {
       sketch: paradigm,
-      version: "3.0.1-alpha.17",
+      version: "3.0.1-alpha.18",
       baud_rate: 115200,
       desc: `Demo ${paradigm.toUpperCase()} firmware`,
     },


### PR DESCRIPTION
## Why

A user on Arch ran the v3.0.1-alpha.17 `.tar.gz` and `.AppImage` and the app never started serving:

```
  API key      : 4952a3ede2d5c7fc42574b212e682e2e
/bin/bash: symbol lookup error: /bin/bash: undefined symbol: rl_print_keybinding
/bin/sh: symbol lookup error: /bin/sh: undefined symbol: rl_print_keybinding
```

Every child process of a frozen build inherits `LD_LIBRARY_PATH`. PyInstaller's bootloader already points it at `<bundle>/_internal`, which ships 36 Ubuntu-built libraries that also exist system-wide — so on Arch, `/bin/bash` loaded the bundle's readline 8.2, which predates `rl_print_keybinding`.

`launcher.py` was adding a **second** poisoned directory on top of that. This PR removes it; the bundle-root half is fixed in Otis-Lab-MUSC/reacher#57.

## Why it was never needed

The llama.cpp binaries carry an `$ORIGIN` RPATH:

```
$ objdump -p _internal/llm/llama-completion | grep RUNPATH
  RUNPATH              $ORIGIN

$ env -u LD_LIBRARY_PATH _internal/llm/llama-completion --version
version: 0.3.0-dev (build 10622, commit 3737e4137)
exit=0
```

They resolve their own libraries, and reacher now passes their directory explicitly when it spawns them. The `PATH` entry is kept — that one is harmless and still useful for operators.

## Note on the bundle's own libraries

Worth recording, since it constrains any future attempt to fix this by simply clearing the variable: the bundled Python extension modules are **not** self-resolving.

```
$ objdump -p _internal/libpython3.11.so.1.0 | grep RUNPATH
  RUNPATH              /opt/hostedtoolcache/Python/3.11.16/x64/lib
```

That is a CI-runner path that exists on no user machine, so the app genuinely needs `LD_LIBRARY_PATH=_internal` for itself. Only children may have it stripped — which is exactly what reacher#57 does.

## Release

Stamped `v3.0.1-alpha.18` and pins `reacher2p>=3.4.0a5`, so `--print-reacher-ref` resolves to `v3.4.0-alpha.5`. That reacher tag must exist before this repo is tagged.

`npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)