### PR TITLE
release: v3.0.1-alpha.19 — pin reacher 3.4.0-alpha.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Cross-platform control application for REACHER operant behavior experiments, with a browser interface and a terminal interface over the same rigs.**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.18-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.19-blue)](https://github.com/Otis-Lab-MUSC/labrynth/releases)
 [![Language](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-orange)](CHANGELOG.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labrynth"
-version = "3.0.1-alpha.18"
+version = "3.0.1-alpha.19"
 description = "Labrynth application shell — build orchestrator and frontend"
 requires-python = ">=3.10"
 dependencies = [
     # PyPI distribution is "reacher2p" (the "reacher" name was taken); the import
     # package is still "reacher" (python -m reacher, importlib hex resolution).
-    "reacher2p>=3.4.0a5",
+    "reacher2p>=3.4.0a6",
     "pyinstaller>=6.0",
 ]
 

--- a/web/README.md
+++ b/web/README.md
@@ -2,7 +2,7 @@
 
 **Browser-based experiment control interface for the REACHER ecosystem**
 
-[![Version](https://img.shields.io/badge/version-3.0.1--alpha.18-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
+[![Version](https://img.shields.io/badge/version-3.0.1--alpha.19-blue)](https://github.com/Otis-Lab-MUSC/labrynth)
 [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labrynth-frontend",
   "private": true,
-  "version": "3.0.1-alpha.18",
+  "version": "3.0.1-alpha.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -14,7 +14,7 @@ export class DemoMachineApiClient extends MachineApiClient {
 
   // --- Health ---
   probeHealth = async () =>
-    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.18", active_sessions: 0 });
+    ({ service: "reacher", device_id: "__local__", hostname: "demo", version: "3.0.1-alpha.19", active_sessions: 0 });
 
   // --- Sessions ---
   listSessions = () => mock.listSessions() as ReturnType<MachineApiClient["listSessions"]>;

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -168,7 +168,7 @@ export const uploadFirmware = async (id: string, paradigm: string, board: string
     board,
     firmware_info: {
       sketch: paradigm,
-      version: "3.0.1-alpha.18",
+      version: "3.0.1-alpha.19",
       baud_rate: 115200,
       desc: `Demo ${paradigm.toUpperCase()} firmware`,
     },


### PR DESCRIPTION
## Why

v3.0.1-alpha.18 fixed the Arch library-path leak but introduced a regression: **the browser stopped opening on startup.**

`clean_environ()` in reacher built its sanitized copy *after* `os.environ.clear()`, so it copied an already-empty environment and wiped `PATH`, `BROWSER`, and `DISPLAY` along with the bundle's library path. `webbrowser.open()` had nothing to launch and returned silently. The server itself was fine — users just had to navigate to `http://localhost:6229` themselves.

Fixed in Otis-Lab-MUSC/reacher#58. **No Labrynth code changes** — this PR is the version stamp and pin bump that pull the fix in.

## What alpha.18 got right

Worth keeping on the record, since this release does not change it. The original Arch bug is genuinely fixed, verified on the published artifacts:

| | child's `LD_LIBRARY_PATH` | `/bin/bash` binds |
|---|---|---|
| alpha.17 | `<bundle>/_internal/llm:<bundle>/_internal` | bundled `libtinfo.so.6` |
| alpha.18 | *(clean)* | `/lib/x86_64-linux-gnu/libtinfo.so.6` |

alpha.19 keeps that and restores the browser launch on top.

## Release

Stamped `v3.0.1-alpha.19`, pins `reacher2p>=3.4.0a6`, so `--print-reacher-ref` resolves to `v3.4.0-alpha.6`. That reacher tag must exist before this repo is tagged.

`npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)