### PR TITLE
Add Cursor Cloud dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,23 @@
+{
+  "name": "Labrynth",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "reacher-backend",
+      "command": "source .venv/bin/activate && export REACHER_STATIC_DIR=\"$(pwd)/web/dist\" && export REACHER_PORT=6229 && python -m reacher",
+      "description": "REACHER backend (FastAPI + WebSocket) on http://localhost:6229, serving the built frontend from web/dist."
+    },
+    {
+      "name": "vite-dev",
+      "command": "cd web && npm run dev",
+      "description": "Vite dev server on http://localhost:5173 with HMR; proxies /api and /ws to the backend on :6229."
+    }
+  ],
+  "ports": [
+    { "name": "reacher-backend", "port": 6229 },
+    { "name": "vite-dev", "port": 5173 }
+  ],
+  "repositoryDependencies": [
+    "github.com/otis-lab-musc/reacher"
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Idempotent bootstrap for the Labrynth development environment.
+#
+# Layers set up here:
+#   1. A Python virtualenv (.venv) with the REACHER backend + the Labrynth CLI.
+#   2. The React frontend (web/) dependencies and a production build (web/dist/).
+#
+# The REACHER backend lives in a separate repository (reacher2p / `import reacher`).
+# It is preferred from a sibling checkout (declared via `repositoryDependencies`)
+# so backend changes are picked up locally; otherwise it falls back to the pinned
+# release on PyPI.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- System dependency: python venv support (Debian/Ubuntu splits it out) ------
+if ! python3 -c 'import ensurepip, venv' >/dev/null 2>&1; then
+  if command -v sudo >/dev/null 2>&1; then
+    sudo apt-get update -qq
+    sudo apt-get install -y python3-venv python3-full
+  else
+    apt-get update -qq
+    apt-get install -y python3-venv python3-full
+  fi
+fi
+
+# --- Python: backend + CLI -----------------------------------------------------
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+python -m pip install --upgrade pip
+
+# Install the REACHER backend: prefer the sibling source checkout, else PyPI.
+if [ -d ../reacher ]; then
+  echo "Installing reacher backend from sibling checkout (../reacher)"
+  pip install -e ../reacher
+else
+  echo "Sibling reacher checkout not found; installing reacher2p from PyPI"
+  pip install "reacher2p"
+fi
+
+# Labrynth's own package + CLI extras (prompt_toolkit, httpx, websockets).
+pip install -e ".[cli]"
+
+# --- Frontend: install deps + build static bundle ------------------------------
+cd web
+npm ci
+npm run build
+
+echo "Labrynth environment setup complete."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repo-managed Cursor Cloud environment so agents (and contributors using Cloud Agents) can set up and run Labrynth end-to-end without manual steps. The setup was validated by installing everything, running the backend + frontend, and exercising the web UI and the Python CLI against a live backend.

## What's included

- **`.cursor/install.sh`** — idempotent bootstrap:
  - Ensures `python3-venv` is present, creates a `.venv`.
  - Installs the REACHER backend editable from the sibling `../reacher` checkout (declared as a repository dependency), falling back to `reacher2p` on PyPI when the sibling isn't present.
  - Installs Labrynth's package + `[cli]` extras (`prompt_toolkit`, `httpx`, `websockets`).
  - Runs `npm ci` and `npm run build` for the frontend.
- **`.cursor/environment.json`** — declares the `reacher` repository dependency, exposes ports `6229` (backend) and `5173` (Vite), and runs two terminals:
  - `reacher-backend` — `python -m reacher` on `:6229` serving `web/dist`.
  - `vite-dev` — Vite dev server on `:5173`, proxying `/api` and `/ws` to `:6229`.

## Verification

- Backend healthy on `:6229` (`/health` → `status: ok`, version `3.4.0-alpha.6`); authenticated API returns the Arduino board list; `/api/auth/token` bootstrap works through the Vite proxy.
- Frontend builds cleanly (`tsc -b && vite build`) and renders in-browser: dark themed UI, WebSocket **online**, local machine online, `SIMULATOR` port available, all nav panels interactive.
- Python CLI TUI connects to the backend and creates a live `SIMULATOR` session (paradigm `fr`), confirmed via `GET /api/sessions` (`active_sessions = 1`).

## Notes

- `avrdude` (real-hardware firmware flashing) is intentionally not installed — it isn't needed for development or the `SIMULATOR` workflow. Add it to `install.sh`/a Dockerfile if hardware flashing from a Cloud Agent is ever required.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eebbff8f-d1f4-42d6-b724-b043a39328e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eebbff8f-d1f4-42d6-b724-b043a39328e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

