### PR TITLE
feat: Replace LLM-based issue filing with GitHub URL prefilling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,15 @@ Machine discovery uses mDNS (polled by `useMachineStore.startDiscoveryPolling`).
   Field values are logged **verbatim** (deliberate — it is what makes bugs
   reproducible); only credential-shaped keys are redacted, and the server
   re-redacts on ingest. See `docs/logging.md` in the reacher repo. About →
-  *Report an issue* flushes the buffer, POSTs `/api/issues/report` (reacher),
-  and a bundled local GGUF summarizes the description + a log excerpt into a
-  GitHub issue when `REACHER_GITHUB_TOKEN` is set. Operator setup:
+  *Report an issue* flushes the buffer and POSTs `/api/issues/prefill`
+  (reacher), which composes a title, Markdown body (description + steps +
+  severity + version + a capped diagnostic excerpt), labels, and a
+  `github.com/<owner>/<repo>/issues/new?…` URL. `ReportIssueModal` shows that
+  composed issue and a *Continue on GitHub* anchor — the user submits it in
+  their own browser under their own GitHub account. The endpoint makes no
+  network or subprocess call, so there is no PAT, no relay, no LLM, and no
+  unavailable state. Note that both target repos are public and log excerpts
+  carry verbatim field values. Setup and rationale:
   [docs/issue-reporting.md](docs/issue-reporting.md).
 - **`components/`** — feature-area folders: `session/`, `configuration/`, `monitor/`, `data/`, `hardware/`, `program/`, `machines/`, `terminal/`, `layout/`, `tutorial/`.
 - **`themes/`** — 5 named themes (`reacher`, `terminal`, `neural`, `midnight`, `ember`), each with a `dark` and `light` palette plus background, font, radius, glass tokens. Theme is applied by writing CSS variables on `:root` (no Tailwind dark-mode toggle alone — `apply()` in `useThemeStore` sets `--color-*`, `--font-*`, etc.). Default: `reacher`. Persistence: `localStorage["labrynth-mode"]`.

--- a/docs/issue-reporting.md
+++ b/docs/issue-reporting.md
@@ -1,58 +1,54 @@
 # In-app issue reporting
 
-Labrynth can turn a researcher’s plain-language description plus a compact
-slice of the current diagnostic run log into a structured GitHub issue. The
-summarizer is a bundled `llama.cpp` binary and a Qwen2.5-1.5B GGUF — there is
-no cloud LLM key. Filing the issue on GitHub is optional and **operator
-configured**.
+Labrynth turns a researcher's plain-language description plus a compact slice of
+the current diagnostic run log into a pre-filled GitHub "New Issue" link. The
+researcher opens that link, reviews the issue in their own browser, and submits
+it under their own GitHub account.
 
-## Operator setup (lab machines)
+There is no LLM in this flow, no GitHub token on the rig, and no service to
+deploy — the backend only builds a URL.
 
-Set these on each rig that should file issues. They are **not** baked into the
-installer.
+## The flow
 
-```bash
-export REACHER_GITHUB_TOKEN=github_pat_...   # fine-grained PAT
-export REACHER_GITHUB_OWNER=Otis-Lab-MUSC    # optional; this is the default
-```
+1. About → *Report an issue* → describe the problem in plain language, with
+   optional steps to reproduce, severity, and target repo.
+2. **Continue** POSTs `/api/issues/prefill`, which composes the title, Markdown
+   body, and labels and returns a `github.com/<owner>/<repo>/issues/new?…` URL.
+3. The modal shows the composed issue and a **Continue on GitHub** link. Opening
+   it lands the researcher on GitHub's new-issue form, pre-filled. Both target
+   repos are public, so this is the moment to scrub subject IDs, doses, or
+   paths before pressing *Create*.
 
-Token scopes:
-
-- Resource: `Otis-Lab-MUSC/labrynth` and `Otis-Lab-MUSC/reacher`
-- Permission: **Issues: Read and write** (enough to create issues and labels)
-
-On Windows, set the same variables in the user or system environment, or in
-whatever wrapper starts Labrynth.
-
-If the token is unset, About → Report an issue still runs the local model and
-lets the user copy the generated markdown. Submit-to-GitHub is disabled.
-
-The GUI installer sets `REACHER_LLM_BIN` and `REACHER_LLM_MODEL` automatically
-from the frozen `llm/` directory. Dev-from-source builds do not ship the GGUF;
-either point those two variables at a local `llama-completion` + GGUF, or the report
-endpoint returns 503.
+Nothing reaches GitHub until the researcher submits the form themselves.
+`/api/issues/prefill` makes no network or subprocess calls of its own.
 
 ## What gets sent to GitHub
 
 A capped excerpt of the current run: process meta (versions, platform), error
 and warning records, recent UI events, and session lifecycle. **Not** the full
-diagnostics ZIP.
+diagnostics ZIP. reacher sizes the excerpt so the encoded URL stays within a
+safe length budget.
 
 Field values in the log are recorded verbatim (subject IDs, doses, paths). The
-report modal discloses this. Treat a filed issue as sensitive as the experiment
-data.
+report modal discloses this, and the researcher sees the full body before
+opening the link. **Both target repositories are public** — treat a filed issue
+as sensitive as the experiment data behind it.
 
 ## Backend requirement
 
-`POST /api/issues/report` and `GET /api/issues/status` live in **reacher**.
-Until a reacher release that includes those routes is published to PyPI, run
-Labrynth against an editable install:
+`POST /api/issues/prefill` lives in **reacher**. It replaces the earlier
+`GET /api/issues/status`, `POST /api/issues/report`, and `POST /api/issues/file`
+endpoints, along with the local summarizer, the direct-PAT filing path, and the
+Cloudflare Worker relay (`services/issue-relay/`), all of which are gone.
+
+Until a reacher release carrying `/prefill` is on PyPI, run Labrynth against an
+editable install:
 
 ```bash
 pip install -e ../reacher
 ```
 
-Then, after that reacher version is on PyPI, pin it here with:
+Then pin it here with:
 
 ```bash
 python scripts/bump-version.py --reacher-pin <reacher-semver>
@@ -60,12 +56,7 @@ python scripts/bump-version.py --reacher-pin <reacher-semver>
 
 Do not hand-edit `pyproject.toml`.
 
-## Installer notes
+## Demo mode
 
-`python build.py` downloads a pinned llama.cpp CPU archive and the Qwen2.5-1.5B
-Q4_K_M GGUF into `.llm-dist/` (SHA-256 verified) and copies them into the GUI
-bundle. Use `--skip-llm` for a fast local GUI build without the ~1.1 GB model.
-`build.py --cli-only` never bundles the LLM.
-
-GitHub release assets must stay under 2 GB; the 1.5B Q4 model is the size
-ceiling for that reason.
+The demo build has no backend, so `DemoMachineApiClient` composes the same
+pre-filled GitHub URL client-side, minus the diagnostic excerpt.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -19,6 +19,15 @@ export interface ValidationResult {
   suggestions: string;
 }
 
+export interface IssuePrefill {
+  title: string;
+  body: string;
+  labels: string[];
+  url: string;
+  repo: string;
+  owner: string;
+}
+
 export type ValidateConfigPayload = {
   paradigm?: string;
   paradigmSettings?: Record<string, unknown>;
@@ -366,25 +375,17 @@ export class MachineApiClient {
     });
 
   // --- Issues ---
-  getIssueStatus = () =>
-    this.request<{ llm: boolean; github: boolean; owner: string; repos: string[] }>("/issues/status");
-  reportIssue = (body: {
+  // Purely local on the backend: builds a pre-filled GitHub "New Issue" URL the
+  // user reviews and submits themselves. Nothing is filed on their behalf.
+  getIssuePrefill = (body: {
     description: string;
     steps?: string;
     severity?: string;
     repo?: string;
     app_version?: string;
-    file?: boolean;
+    labels?: string[];
   }) =>
-    this.request<{
-      title: string;
-      body: string;
-      labels: string[];
-      summarized: boolean;
-      filed: boolean;
-      html_url: string | null;
-      repo: string;
-    }>("/issues/report", {
+    this.request<IssuePrefill>("/issues/prefill", {
       method: "POST",
       body: JSON.stringify(body),
     });

--- a/web/src/api/demoClient.ts
+++ b/web/src/api/demoClient.ts
@@ -1,4 +1,4 @@
-import { MachineApiClient } from "./client";
+import { MachineApiClient, type IssuePrefill } from "./client";
 import * as mock from "./mock";
 import type { BoardInfo, BoardType } from "../types";
 
@@ -81,45 +81,50 @@ export class DemoMachineApiClient extends MachineApiClient {
   setFileConfig = (id: string, body: { filename?: string; destination?: string }) =>
     mock.setFileConfig(id, body) as ReturnType<MachineApiClient["setFileConfig"]>;
 
-  // --- Issues (never talks to GitHub in demo mode) ---
-  getIssueStatus = async () => ({
-    llm: true,
-    github: false,
-    owner: "Otis-Lab-MUSC",
-    repos: ["labrynth", "reacher"],
-  });
-  reportIssue = async (body: {
+  // --- Issues ---
+  // The real endpoint is purely local (it only builds a URL), so the demo
+  // build assembles the same pre-filled GitHub link client-side, minus the
+  // diagnostic log excerpt the backend would attach.
+  getIssuePrefill = async (body: {
     description: string;
     steps?: string;
     severity?: string;
     repo?: string;
     app_version?: string;
-    file?: boolean;
-  }) => ({
-    title: body.description.trim().split("\n")[0]?.slice(0, 72) || "Demo issue",
-    body: [
+    labels?: string[];
+  }): Promise<IssuePrefill> => {
+    const owner = "Otis-Lab-MUSC";
+    const repo = body.repo === "reacher" ? "reacher" : "labrynth";
+    const title = body.description.trim().split("\n")[0]?.slice(0, 72) || "Demo issue";
+    const issueBody = [
       "## Description",
-      body.description,
+      body.description.trim(),
       "",
       "## Steps to Reproduce",
-      body.steps?.trim() || "Unknown — needs investigation",
-      "",
-      "## Expected Behavior",
-      "Unknown — needs investigation",
-      "",
-      "## Actual Behavior",
-      "See description.",
+      body.steps?.trim() || "Unknown \u2014 needs investigation",
       "",
       "## Severity",
       body.severity || "unspecified",
       "",
+      "## Version",
+      body.app_version || "unknown",
+      "",
       "## Reporter Notes",
-      "Demo mode — this report was not filed on GitHub.",
-    ].join("\n"),
-    labels: ["bug"],
-    summarized: true,
-    filed: false,
-    html_url: null,
-    repo: body.repo || "labrynth",
-  });
+      "Filed from the demo site \u2014 no diagnostic log is available.",
+    ].join("\n");
+    const labels = [...(body.labels ?? []), "develop"];
+    const params = new URLSearchParams({
+      title,
+      body: issueBody,
+      labels: labels.join(","),
+    });
+    return {
+      title,
+      body: issueBody,
+      labels,
+      url: `https://github.com/${owner}/${repo}/issues/new?${params.toString()}`,
+      repo,
+      owner,
+    };
+  };
 }

--- a/web/src/components/layout/ReportIssueModal.tsx
+++ b/web/src/components/layout/ReportIssueModal.tsx
@@ -1,48 +1,32 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Copy, ExternalLink, X } from "lucide-react";
-import { getLocalClient } from "../../api/client";
+import { getLocalClient, type IssuePrefill } from "../../api/client";
 import { DemoMachineApiClient } from "../../api/demoClient";
 import { flush, log } from "../../logging";
 import { useReportStore } from "../../store/useReportStore";
-import { useSessionStore } from "../../store/useSessionStore";
 import { LOCAL_PLACEHOLDER_ID, useMachineStore } from "../../store/useMachineStore";
 import { useTutorialStore } from "../../store/useTutorialStore";
 
 type Severity = "" | "minor" | "moderate" | "critical";
 type Repo = "labrynth" | "reacher";
 
-interface IssueStatus {
-  llm: boolean;
-  github: boolean;
-  owner: string;
-  repos: string[];
-}
-
-interface ReportResult {
-  title: string;
-  body: string;
-  labels: string[];
-  summarized: boolean;
-  filed: boolean;
-  html_url: string | null;
-  repo: string;
-}
-
 export function ReportIssueModal() {
   const open = useReportStore((s) => s.open);
-  const prefill = useReportStore((s) => s.prefill);
+  const prefillText = useReportStore((s) => s.prefill);
   const closeReport = useReportStore((s) => s.closeReport);
 
   const [description, setDescription] = useState("");
   const [steps, setSteps] = useState("");
   const [severity, setSeverity] = useState<Severity>("");
   const [repo, setRepo] = useState<Repo>("labrynth");
-  const [status, setStatus] = useState<IssueStatus | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<ReportResult | null>(null);
+
+  // Single-step flow: form → pre-filled GitHub link the user opens and submits.
+  const [prefill, setPrefill] = useState<IssuePrefill | null>(null);
   const [copied, setCopied] = useState(false);
+
   const closeRef = useRef<HTMLButtonElement>(null);
   const demoMode = useTutorialStore((s) => s.demoMode);
 
@@ -53,32 +37,17 @@ export function ReportIssueModal() {
     return useMachineStore.getState().getClient(LOCAL_PLACEHOLDER_ID) ?? getLocalClient();
   }
 
-  const sessionRunning = useSessionStore((s) =>
-    [...s.sessions.values()].some((sess) => sess.state === "running"),
-  );
-
   useEffect(() => {
     if (!open) return;
-    setDescription(prefill);
+    setDescription(prefillText);
     setSteps("");
     setSeverity("");
     setRepo("labrynth");
     setError(null);
-    setResult(null);
+    setPrefill(null);
     setCopied(false);
     closeRef.current?.focus();
-  }, [open, prefill]);
-
-  useEffect(() => {
-    if (!open) return;
-    setStatus(null);
-    apiClient()
-      .getIssueStatus()
-      .then(setStatus)
-      .catch(() =>
-        setStatus({ llm: false, github: false, owner: "Otis-Lab-MUSC", repos: ["labrynth", "reacher"] }),
-      );
-  }, [open]);
+  }, [open, prefillText]);
 
   useEffect(() => {
     if (!open) return;
@@ -91,53 +60,44 @@ export function ReportIssueModal() {
 
   if (!open) return null;
 
-  const llmReady = Boolean(status?.llm);
-  const githubReady = Boolean(status?.github) && !demoMode;
-  const canSubmit = description.trim().length > 0 && llmReady && !busy;
+  const canSubmit = description.trim().length > 0 && !busy;
+  const markdown = prefill ? `# ${prefill.title}\n\n${prefill.body}` : "";
 
-  async function handleSubmit() {
+  async function handlePrepare() {
     setBusy(true);
     setError(null);
-    setResult(null);
     log("ui.issue_report", { repo, severity, demoMode }, "info", {
-      msg: "Issue report submitted",
+      msg: "Issue report prepared",
       src: "ReportIssueModal",
     });
     try {
+      // The backend attaches a slice of this run's log, so make sure the
+      // buffered client-side entries have landed before it reads them.
       await flush();
-      const data = await apiClient().reportIssue({
+      const data = await apiClient().getIssuePrefill({
         description: description.trim(),
         steps: steps.trim(),
         severity,
         repo,
         app_version: __APP_VERSION__,
-        file: githubReady,
       });
-      setResult(data);
+      setPrefill(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Report failed");
+      setError(err instanceof Error ? err.message : "Could not prepare the report");
     } finally {
       setBusy(false);
     }
   }
 
   async function handleCopy() {
-    if (!result) return;
-    const text = `# ${result.title}\n\n${result.body}`;
     try {
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(markdown);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
       setError("Could not copy to clipboard");
     }
   }
-
-  const submitLabel = busy
-    ? "Working…"
-    : githubReady
-      ? "Submit to GitHub"
-      : "Summarize";
 
   return createPortal(
     <div
@@ -155,7 +115,7 @@ export function ReportIssueModal() {
       >
         <div className="mb-4 flex items-center justify-between">
           <h3 id="report-issue-title" className="text-base font-semibold text-theme-text">
-            Report an issue
+            {prefill ? "Review on GitHub" : "Report an issue"}
           </h3>
           <button
             ref={closeRef}
@@ -168,31 +128,38 @@ export function ReportIssueModal() {
           </button>
         </div>
 
-        {result ? (
+        {prefill ? (
           <div className="space-y-3">
-            {result.filed && result.html_url ? (
-              <p className="text-sm text-theme-text/80">
-                Filed{" "}
-                <a
-                  href={result.html_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-accent hover:underline"
-                >
-                  {result.title} <ExternalLink size={12} />
-                </a>
-              </p>
-            ) : (
-              <p className="text-sm text-theme-text/80">
-                {result.summarized
-                  ? "Summary ready. GitHub filing is not configured on this machine — copy the markdown below."
-                  : "The local model could not summarize this report. A fallback draft is below."}
-              </p>
-            )}
-            <pre className="max-h-64 overflow-auto rounded border border-theme-border bg-black/20 p-3 text-xs text-theme-text/80 whitespace-pre-wrap">
-              {`# ${result.title}\n\n${result.body}`}
-            </pre>
+            <p className="text-xs text-theme-text/60">
+              Your report is ready. Continuing opens a pre-filled new issue on the{" "}
+              <span className="font-medium">{prefill.repo}</span> repository in a new tab — review
+              it there and press <span className="font-medium">Create</span> to submit it under
+              your own GitHub account. Nothing is posted until you do.
+            </p>
+            <p className="text-xs text-amber-500/90">
+              Both repositories are public. Remove any subject IDs, doses, or file paths you
+              don&apos;t want public before submitting.
+            </p>
+
+            <div className="rounded border border-theme-border bg-black/20 p-3">
+              <p className="text-xs font-medium text-theme-text">{prefill.title}</p>
+              <pre className="mt-2 max-h-56 overflow-y-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-theme-text/70">
+                {prefill.body}
+              </pre>
+            </div>
+
+            {error && <p className="text-xs text-red-500">{error}</p>}
+
             <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  setPrefill(null);
+                  setError(null);
+                }}
+                className="rounded px-3 py-1.5 text-sm text-theme-text hover:bg-accent/10"
+              >
+                Back
+              </button>
               <button
                 onClick={handleCopy}
                 className="flex items-center gap-1.5 rounded border border-theme-border px-3 py-1.5 text-xs text-theme-text/70 transition hover:border-accent hover:text-accent"
@@ -200,24 +167,29 @@ export function ReportIssueModal() {
                 <Copy size={11} />
                 {copied ? "Copied" : "Copy markdown"}
               </button>
-              <button
-                onClick={closeReport}
-                className="rounded bg-accent px-3 py-1.5 text-xs text-white hover:opacity-90"
+              <a
+                href={prefill.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() =>
+                  log("ui.issue_continue", { repo: prefill.repo }, "info", {
+                    msg: "Opened pre-filled GitHub issue",
+                    src: "ReportIssueModal",
+                  })
+                }
+                className="inline-flex items-center gap-1.5 rounded bg-accent px-3 py-1.5 text-sm text-white hover:opacity-90"
               >
-                Done
-              </button>
+                Continue on GitHub <ExternalLink size={12} />
+              </a>
             </div>
           </div>
         ) : (
           <>
             <p className="mb-3 text-xs text-theme-text/60">
-              Describe what happened in your own words. A local model on this machine will turn
-              that description plus a compact slice of this run&apos;s diagnostic log into a
-              technical GitHub issue. No cloud AI key is required.
-            </p>
-            <p className="mb-4 text-xs text-amber-500/90">
-              The log excerpt can include experiment identifiers (subject IDs, doses, file paths).
-              Only submit if you are comfortable sending that excerpt to GitHub.
+              Describe what happened in your own words. That description, plus a compact slice of
+              this run&apos;s diagnostic log, is turned into a GitHub issue draft. The last step
+              opens it in your browser so you can review it and submit it yourself — nothing is
+              posted on your behalf.
             </p>
 
             <label className="mb-3 block text-xs font-medium text-theme-text/70">
@@ -226,6 +198,7 @@ export function ReportIssueModal() {
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={5}
+                maxLength={2000}
                 className="mt-1 w-full rounded border border-theme-border bg-transparent px-2 py-1.5 text-sm text-theme-text focus:border-accent focus:outline-none"
                 placeholder="e.g. The camera feed froze during the trial and I had to restart…"
               />
@@ -237,6 +210,7 @@ export function ReportIssueModal() {
                 value={steps}
                 onChange={(e) => setSteps(e.target.value)}
                 rows={3}
+                maxLength={1500}
                 className="mt-1 w-full rounded border border-theme-border bg-transparent px-2 py-1.5 text-sm text-theme-text focus:border-accent focus:outline-none"
                 placeholder="1. Started a new session  2. Ran 3 trials  3. …"
               />
@@ -269,30 +243,9 @@ export function ReportIssueModal() {
               </label>
             </div>
 
-            {sessionRunning && (
-              <p className="mb-3 text-xs text-amber-500/90">
-                A session is running. Summarization uses a small amount of CPU and may take up to
-                two minutes.
-              </p>
-            )}
-
             {demoMode && (
               <p className="mb-3 text-xs text-theme-text/50">
-                Demo mode: nothing will be filed on GitHub.
-              </p>
-            )}
-
-            {status && !status.llm && (
-              <p className="mb-3 text-xs text-red-500">
-                The local summarizer is not available on this build. Issue reporting needs the
-                bundled llama.cpp model.
-              </p>
-            )}
-
-            {status && status.llm && !githubReady && !demoMode && (
-              <p className="mb-3 text-xs text-theme-text/50">
-                GitHub filing is not configured (no REACHER_GITHUB_TOKEN). You can still summarize
-                and copy the markdown.
+                Demo mode: no diagnostic log is attached.
               </p>
             )}
 
@@ -307,11 +260,11 @@ export function ReportIssueModal() {
                 Cancel
               </button>
               <button
-                onClick={handleSubmit}
+                onClick={handlePrepare}
                 disabled={!canSubmit}
                 className="rounded bg-accent px-3 py-1.5 text-sm text-white hover:opacity-90 disabled:opacity-40"
               >
-                {submitLabel}
+                {busy ? "Preparing…" : "Continue"}
               </button>
             </div>
           </>


### PR DESCRIPTION
## Summary

Replaces the previous LLM-based issue filing approach with a simpler flow that pre-fills GitHub issue URLs:

- Removed bundled GGUF, `llama.cpp` binary, and local summarizer requirement
- Removed GitHub token requirement from installers and server
- Removed issue-relay Worker (no longer needed)
- Backend's `/api/issues/prefill` endpoint now composes title, body, and labels into a pre-filled GitHub issue URL
- Researcher opens the URL in their own browser and submits under their own GitHub account

No token, no network calls at filing time, no unavailable state.

Fixes Otis-Lab-MUSC/reacher#59

## Testing

- [ ] Open About → Report an issue
- [ ] Fill in description, steps, severity
- [ ] Verify **Continue** POSTs to `/api/issues/prefill`
- [ ] Confirm modal shows pre-filled issue body and **Continue on GitHub** link
- [ ] Open the link and verify it lands on GitHub's new-issue form with fields pre-filled