### PR TITLE
chore(ci): Add pull_request CI running ESLint, tsc, and version consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  PYTHON_VERSION: '3.11'
+  NODE_VERSION: '20'
+
+jobs:
+  # Frontend gate — ESLint + the TypeScript project build. `npm run build` runs
+  # `tsc -b` before vite, so type errors already break release builds; running
+  # `tsc -b` here surfaces them on the PR instead of at tag time.
+  #
+  # Deliberately no `--max-warnings 0`: the tree carries 34 pre-existing
+  # react-hooks warnings. Errors fail the job, warnings do not.
+  frontend:
+    name: frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: TypeScript build
+        run: npx tsc -b
+
+  # Version gate — pyproject.toml is the source of truth; verify web/package.json
+  # and the README badge agree with it. Catches a hand-edited version, which
+  # `scripts/bump-version.py` exists to prevent.
+  version:
+    name: version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Check version consistency
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)
+          echo "pyproject.toml version: $version"
+          python scripts/bump-version.py --check "$version"


### PR DESCRIPTION
## Problem

labrynth has no `pull_request` CI. The only workflows are `build-installers.yml` and `build-prerelease.yml` (both tag-triggered) and `deploy-demo.yml` (push to `main`). Nothing checks a pull request before it reaches `main`, so a type error or a hand-edited version number is only caught at tag time — during a release build.

## What changed

- `.github/workflows/ci.yml` — new, two jobs on `pull_request` and on push to `main`:
  - **frontend** — `npm ci` → `npm run lint` → `npx tsc -b` (Node 20, npm cache).
  - **version** — reads the version from `pyproject.toml` and runs the existing `scripts/bump-version.py --check` to confirm `web/package.json`, both README badges, and the demo version strings agree.

Nothing else is touched. No source files, no dependencies.

## Notes for review

- **No test framework is added.** `CLAUDE.md` is explicit that the project has none by design; this PR does not change that. It only wires up checks that already exist and are already documented as the working verification path.
- **ESLint runs without `--max-warnings 0`.** The tree currently has 34 pre-existing `react-hooks` warnings. Errors fail the job; warnings do not. Tightening this later is a separate decision.
- `npm run build` already runs `tsc -b` before vite, so type errors were always release-blocking — this just moves the signal earlier.
- Unrelated observation, not fixed here: `CLAUDE.md:89` states `npm run lint` is broken because no flat ESLint config exists. That is stale — `web/eslint.config.js` was added in `75f33e676` and lint runs clean.

## Verification

Both jobs were run locally against this branch before pushing.

```
$ cd web && npm run lint
✖ 34 problems (0 errors, 34 warnings)
```
(exit 0 — warnings only)

```
$ version=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)
$ python3 scripts/bump-version.py --check "$version"
Checking all files match version 3.0.1-alpha.21:
  OK       pyproject.toml: 3.0.1-alpha.21
  OK       README.md (badge): 3.0.1--alpha.21
  OK       web/README.md (badge): 3.0.1--alpha.21
  OK       web/src/api/demoClient.ts (demo version): 3.0.1-alpha.21
  OK       web/src/api/mock.ts (demo version): 3.0.1-alpha.21
  OK       web/package.json: 3.0.1-alpha.21
All files consistent.
```

`npx tsc -b` is verified by this PR's own CI run — a local `--dry` build does not type-check, so this run is its first real proof.

## Risk / not changed

Low. Adding a workflow cannot affect the built application. The `push: branches: [main]` trigger duplicates a little work on merge but keeps `main` itself green.

This PR is the base for the rest of tonight's labrynth issue branches, so that each of those PRs gets checked by this workflow without anything being merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLiaPgYXGBWyZ1K5BoBZev