### PR TITLE
feat(program): Restore CS+/CS- pulse config codes to Pavlovian presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  PYTHON_VERSION: '3.11'
+  NODE_VERSION: '20'
+
+jobs:
+  # Frontend gate — ESLint + the TypeScript project build. `npm run build` runs
+  # `tsc -b` before vite, so type errors already break release builds; running
+  # `tsc -b` here surfaces them on the PR instead of at tag time.
+  #
+  # Deliberately no `--max-warnings 0`: the tree carries 34 pre-existing
+  # react-hooks warnings. Errors fail the job, warnings do not.
+  frontend:
+    name: frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: TypeScript build
+        run: npx tsc -b
+
+  # Version gate — pyproject.toml is the source of truth; verify web/package.json
+  # and the README badge agree with it. Catches a hand-edited version, which
+  # `scripts/bump-version.py` exists to prevent.
+  version:
+    name: version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Check version consistency
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)
+          echo "pyproject.toml version: $version"
+          python scripts/bump-version.py --check "$version"

--- a/web/src/components/program/presets/pavlovianPresets.ts
+++ b/web/src/components/program/presets/pavlovianPresets.ts
@@ -72,6 +72,10 @@ export const PAV_ACQUISITION_PRESET: SessionPreset = {
     217: 20000, // ITI Min (ms)
     218: 50000, // ITI Max (ms)
     219: 0,     // Pulse Config
+    374: 0,     // CS+ Pulse On (ms) — continuous
+    375: 0,     // CS+ Pulse Off (ms)
+    384: 200,   // CS- Pulse On (ms)
+    385: 200,   // CS- Pulse Off (ms)
   },
   limitDefaults: { limitType: "Trials", timeLimit: 7200, infusionLimit: 100, delay: 10 },
 };
@@ -104,6 +108,10 @@ export const PAV_REVERSAL_PRESET: SessionPreset = {
     217: 20000, // ITI Min (ms)
     218: 50000, // ITI Max (ms)
     219: 0,     // Pulse Config
+    374: 0,     // CS+ Pulse On (ms) — continuous
+    375: 0,     // CS+ Pulse Off (ms)
+    384: 200,   // CS- Pulse On (ms)
+    385: 200,   // CS- Pulse Off (ms)
   },
   limitDefaults: { limitType: "Trials", timeLimit: 7200, infusionLimit: 100, delay: 10 },
 };


### PR DESCRIPTION
Closes #24

Stacked on #118 (`ci/enable-pr-checks`) — please retarget to `main` once #118 merges.

## Problem
Selecting the Pavlovian Acquisition or Reversal preset did not configure CS+/CS- cue pulsing (continuous vs. pulsed tone). A bench user applying either preset got a silently-wrong tone pattern unless they separately opened Pavlovian Parameters and set pulse config by hand.

## Root cause / current state
`web/src/components/program/presets/pavlovianPresets.ts` — as of base commit `5f39a95d5`, both `PAV_ACQUISITION_PRESET` and `PAV_REVERSAL_PRESET` already fully implement every other part of issue #24's spec (CS+ 100%/CS- 0% reward, swapped in Reversal; ITI min 20s/mean 30s/max 50s at codes 217/216/218) — this was done in a prior PR, not scaffolding as the issue text describes. The one real gap: codes 374/375/384/385 (CS+/CS- pulse on/off) were deliberately removed from these presets in PR #70 (`e9705b92d`, 2026-06-18 13:37) because the Pavlovian firmware at the time did not implement them ("command not found" at runtime).

That removal is now stale. A firmware commit (`reacher` repo, `0f51205 fix(pavlovian): implement CS+/CS- pulse command handlers 374/375/384/385`) landed ~1 hour later the same day (2026-06-18 14:38) and is contained in every reacher tag since `v3.0.0`, including the version this repo pins (`reacher2p>=3.4.0a8` in `pyproject.toml`). I verified in the firmware source (`reacher/firmware/pavlovian/pavlovian.ino:322-340`) that `CUE_SET_PULSE_ON`/`CUE_SET_PULSE_OFF`/`CUE2_SET_PULSE_ON`/`CUE2_SET_PULSE_OFF` are real, implemented command cases with the exact same defaults (CS+ continuous 0/0, CS- pulsed 200/200) already used as fallback defaults in `PavlovianSettings.tsx`'s `CODE_DEFAULTS`.

## What changed
- `web/src/components/program/presets/pavlovianPresets.ts` — restore `374: 0, 375: 0, 384: 200, 385: 200` to `pavlovianParams` on both `PAV_ACQUISITION_PRESET` and `PAV_REVERSAL_PRESET` (CS+ continuous / CS- pulsed 200/200 in both — the issue only specifies swapping reward assignment between the two presets, not pulse pattern).

## Acceptance criteria
- [x] Selecting Acquisition preset applies CS+ reward (100%), CS− no reward (0%), and ITI min/mean/max of 20/30/50 s to all relevant fields — already true pre-PR; re-verified unchanged (`pavlovianParams` 206/207/216/217/218).
- [x] Selecting Reversal preset correctly swaps CS+ and CS− reward assignments — already true pre-PR; re-verified unchanged (206/207 swapped between the two presets).
- [x] Zustand store reflects applied preset values immediately after `applySessionPreset()` completes — `ProgramPanel.tsx:195-196` calls `setPavlovianParams(activeSessionId, preset.pavlovianParams)` unconditionally after the command-send loop, so the newly-restored 374/375/384/385 flow into the store the same way 206-219 already do. No change needed to this wiring.
- [x] Commands 206–218, 374–375, 384–385 verified **statically** as sent in the correct order — `ProgramPanel.tsx:182-185` iterates `Object.entries(preset.pavlovianParams)` and sends each via `sendCommand`; JS preserves ascending numeric order for integer-like keys, so the send order is 206,207,...,219,374,375,384,385. **NOT verified: Arduino acknowledgment.** I have no hardware rig in this environment — see Risk section.
- [x] Applying a preset does not clobber unrelated hardware settings — unchanged by this PR; `pavlovianParams` is a separate dispatch path from the `hardware` merge/disarm logic in `applySessionPreset()` (`ProgramPanel.tsx:96-119`), which this diff does not touch.

## Verification
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option.

$ npx tsc -b
(no output, exit 0)
```

## Risk / not changed
**This PR needs bench validation on a real Arduino rig before merge.** I confirmed statically (reading the pinned firmware's C++ source) that `pavlovian.ino` implements handlers for codes 374/375/384/385 with matching defaults, and that the JS send order is correct — but I cannot execute the actual serial round-trip or confirm the Arduino ACKs each command from this environment. Nothing else in `pavlovianPresets.ts`, `ProgramPanel.tsx`, or the store wiring was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLiaPgYXGBWyZ1K5BoBZev