### PR TITLE
bug: Don't clobber a disarmed device's settings when applying a session preset

### DIFF
--- a/web/src/components/configuration/ConfigurationPanel.tsx
+++ b/web/src/components/configuration/ConfigurationPanel.tsx
@@ -189,13 +189,16 @@ export function ConfigurationPanel() {
         if (key === "testMode") {
           result.testMode = value as boolean;
         } else if (key in result) {
-          const merged = {
-            ...(prev as unknown as Record<string, unknown>)[key] as object,
-            ...(value as object),
-          };
-          if (key in armOverrides) {
-            (merged as Record<string, unknown>).armed = armOverrides[key];
-          }
+          const valueObj = value as unknown as Record<string, unknown>;
+          const armed = key in armOverrides ? armOverrides[key] : (valueObj.armed as boolean | undefined);
+          const prevDevice = (prev as unknown as Record<string, unknown>)[key] as object;
+          // A disarmed device keeps whatever settings it already had instead of
+          // inheriting the preset's frequency/duration — those preset values exist
+          // only to seed SessionPresetCard's display and the device's config if the
+          // user re-arms it via an arm override (handled by the branch below).
+          const merged = armed === false
+            ? { ...prevDevice, armed: false }
+            : { ...prevDevice, ...valueObj, armed };
           (result as unknown as Record<string, unknown>)[key] = merged;
         }
       }

--- a/web/src/components/program/ProgramPanel.tsx
+++ b/web/src/components/program/ProgramPanel.tsx
@@ -99,13 +99,16 @@ export function ProgramPanel() {
         if (key === "testMode") {
           result.testMode = value as boolean;
         } else if (key in result) {
-          const merged = {
-            ...(prev as unknown as Record<string, unknown>)[key] as object,
-            ...(value as object),
-          };
-          if (key in armOverrides) {
-            (merged as Record<string, unknown>).armed = armOverrides[key];
-          }
+          const valueObj = value as unknown as Record<string, unknown>;
+          const armed = key in armOverrides ? armOverrides[key] : (valueObj.armed as boolean | undefined);
+          const prevDevice = (prev as unknown as Record<string, unknown>)[key] as object;
+          // A disarmed device keeps whatever settings it already had instead of
+          // inheriting the preset's frequency/duration — those preset values exist
+          // only to seed SessionPresetCard's display and the device's config if the
+          // user re-arms it via an arm override (handled by the branch below).
+          const merged = armed === false
+            ? { ...prevDevice, armed: false }
+            : { ...prevDevice, ...valueObj, armed };
           (result as unknown as Record<string, unknown>)[key] = merged;
         }
       }


### PR DESCRIPTION
Closes #12

## Problem

Loading the SA Extinction preset pre-fills Cue 1's frequency (8000Hz) and duration (1600ms) in the settings panel, even though Cue 1 is disarmed by that preset. The reporter read this as "the extinction preset also loads a sound cue" — no tone is actually delivered (the cue is disarmed), but the settings-panel display is misleading.

## Root cause

`applySessionPreset`'s hardware-merge step (`web/src/components/program/ProgramPanel.tsx:96-119`, duplicated at `web/src/components/configuration/ConfigurationPanel.tsx:186-209`) unconditionally spreads every field of every device object in `preset.hardware` onto session state:

```ts
const merged = {
  ...(prev as unknown as Record<string, unknown>)[key] as object,
  ...(value as object),
};
```

`SA_EXTINCTION_PRESET.hardware.primaryCue` (`web/src/components/program/presets/frSaPresets.ts:108`, mirrored for the lite variant at `frLitePresets.ts:73`) is `{ armed: false, frequency: 8000, duration: 1600, ... }`. The `armed` flag is respected everywhere a command gets sent, but the merge step spreads `frequency`/`duration` regardless — so a disarmed device's settings-panel fields get overwritten with the preset's values anyway. `CueControl.tsx` renders those frequency/duration inputs unconditionally, with no `armed` gate, which is what makes the overwrite visible.

**This pattern is not extinction-specific.** Every FR/FR-lite preset's `OPTIONAL_HARDWARE` pre-fills every optional device the same way — `laser` (40Hz/5000ms), `secondaryCue` (2900Hz/1000ms), `secondaryPump` (3000ms) — all `armed: false` with real, non-null values, and all rendered unconditionally by `LaserControl.tsx`/`CueControl.tsx`/`PumpControl.tsx`. I confirmed this with the owner before widening the fix beyond `primaryCue`; see the scope note in the issue thread.

## What changed

In both `ProgramPanel.tsx` and `ConfigurationPanel.tsx`, the merge now computes the device's *final* armed state first (arm-toggle override if the user set one via `SessionPresetCard`, else the preset's own `armed` flag), and branches on it:

- **Final armed state is `false`:** keep the device's existing settings-panel values untouched, only flip `armed: false`. The preset's placeholder frequency/duration is not applied.
- **Final armed state is `true`:** unchanged from before — spread the preset's values onto the device, same as the old unconditional behavior.

```ts
const valueObj = value as unknown as Record<string, unknown>;
const armed = key in armOverrides ? armOverrides[key] : (valueObj.armed as boolean | undefined);
const prevDevice = (prev as unknown as Record<string, unknown>)[key] as object;
const merged = armed === false
  ? { ...prevDevice, armed: false }
  : { ...prevDevice, ...valueObj, armed };
```

### Why the preset placeholder values stay in the preset objects (not fixed there)

`SessionPresetCard`'s `DeviceRow` reads `preset.hardware[entry.key]` directly to show each device's params next to its arm/disarm toggle, and lets the user flip a disarmed device to armed *before* clicking Apply (`armOverrides`). If Cue 1 is toggled armed on the extinction card, `applySessionPreset` needs `SA_EXTINCTION_PRESET.hardware.primaryCue.frequency/duration` to still be there so the device gets sensible values (8000Hz/1600ms) instead of whatever was previously in state (possibly blank/default). `EXTINCTION_DEVICES` marking `primaryCue`/`primaryPump` as `required: false` with role "Disabled during extinction" is exactly this affordance — extinction with a cue present and extinction with a cue absent are both real protocols, and removing the preset's values entirely would break arming Cue 1 back on. The fix only changes what happens when the *final* state is disarmed.

### `applySessionPreset` command-sending (step 2) — deliberately unchanged

Both files' `applySessionPreset` also has a second block that sends live ARM/DISARM + parameter commands to a connected/stopped session. That block still sends frequency/duration commands for a preset-disarmed device (e.g., writes 8000/1600 to Cue 1's firmware registers even while sending the DISARM command). This is left as-is: the hardware `Arm` button in `CueControl`/`LaserControl`/etc. only sends an ARM command, not frequency/duration — so a device someone arms manually *after* applying a preset relies on those registers already being pre-configured by the preset. Changing this would alter live serial traffic to hardware I can't test against in this environment, and the reported bug is about the settings-panel display, not firmware state. Flagging as a possible separate follow-up if the owner wants firmware registers to also reflect "keep prior value" semantics.

### Duplication between `ProgramPanel.tsx` and `ConfigurationPanel.tsx`

Confirmed the merge logic is duplicated verbatim between the two files (as suspected) and applied the identical fix to both rather than extracting a shared helper — extracting one now would also have to account for a pre-existing, unrelated divergence between the two files' step-2 param-sending loops (`ProgramPanel.tsx` gates the `leverFilter` param through `leverFilterActive()`; `ConfigurationPanel.tsx`'s copy does not), which I left untouched as out of scope for this fix.

## Full list of presets/devices affected

| File | Preset(s) | Device(s) with non-null values while disarmed |
|---|---|---|
| `frSaPresets.ts` | `SA_HIGH_PRESET`, `SA_MID_PRESET`, `SA_LOW_PRESET` | `laser`, `secondaryCue`, `secondaryPump`, `slm` (see below) |
| `frSaPresets.ts` | `SA_EXTINCTION_PRESET` | `primaryCue`, `primaryPump`, `laser`, `secondaryCue`, `secondaryPump`, `slm` (see below) |
| `frLitePresets.ts` | `SA_HIGH_LITE_PRESET`, `SA_MID_LITE_PRESET`, `SA_LOW_LITE_PRESET` | `laser`, `secondaryCue`, `secondaryPump` |
| `frLitePresets.ts` | `SA_EXTINCTION_LITE_PRESET` | `primaryCue`, `primaryPump`, `laser`, `secondaryCue`, `secondaryPump` |
| `pavlovianPresets.ts` | `PAV_ACQUISITION_PRESET`, `PAV_REVERSAL_PRESET` | `slm` (see below) |

`microscope`'s config fields (`frameRate`/`frameAveraging`) are `null` in every preset, so there was nothing to clobber there. `lickCircuit` has no frequency/duration fields.

`slm` is the one device I initially got wrong here (caught in review): `frSaPresets.ts:41` and `pavlovianPresets.ts:34` both have `slm: { armed: false, pin: 11, laserFrequency: null, laserDuration: null }` in `OPTIONAL_HARDWARE`, and neither preset overrides it back to armed — `laserFrequency`/`laserDuration` are `null` (nothing to clobber), but **`pin: 11` is non-null**, so applying any FR-SA or Pavlovian preset previously reset `hardwareUi.slm.pin` to `11` even though `slm` stays disarmed; now it doesn't. (`frLitePresets.ts:21` destructures `slm`/`microscope` out of its `OPTIONAL_HARDWARE`, so the lite presets are genuinely unaffected by this device.)

This delta is unobservable, for two independent reasons. First, `defaultHardwareUiState()` (`useSessionStore.ts:58`) already initializes `slm` to the identical `{ armed: false, pin: 11, laserFrequency: null, laserDuration: null }`, so a fresh session sees no change from this fix. Second, and more fundamentally, `hardwareUi.slm.pin` is never written anywhere else in the frontend — `SLMControl.tsx` has no input bound to it (its own `<PinField component="slm" />` writes to a completely separate `session.pinOverrides` map instead), `PRESET_COMMAND_MAP.slm.params` (`devicePresets.ts:45`) only forwards `laserFrequency`/`laserDuration` as live commands, and no WebSocket handler touches it. So `hardwareUi.slm.pin` can never hold any value but its initial `11` in the running app, in either the old or new behavior — this fix changes what the merge *would* do to a divergent `slm.pin`, but no reachable app state ever has one to protect.

**Laser is unaffected in Pavlovian** despite sharing the same `armed: false` + placeholder pattern: both `PAV_ACQUISITION_PRESET` and `PAV_REVERSAL_PRESET` explicitly override `laser` to `armed: true`, and `lickCircuit` is `armed: true` there too.

## Verification

Baseline (unmodified `main` @ `d2028a3b1`, `cd web`):
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)
$ npx tsc -b
(no output — clean)
```

Post-change:
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)
$ npx tsc -b
(no output — clean)
```
Same 34 pre-existing warnings, 0 errors, both before and after — no new lint/type issues.

I also exercised the exact merge branch (copied verbatim from the diff) against the real, esbuild-transpiled `frSaPresets.ts` preset objects in a standalone script, asserting:
- `SA_EXTINCTION_PRESET.hardware.primaryCue`, no arm override → keeps prior settings, disarms (the bug case).
- Same, with `armOverrides.primaryCue = true` (card arm-toggle) → gets the preset's 8000Hz/1600ms.
- `SA_HIGH_PRESET.hardware.primaryCue` (armed by design, no override) → byte-identical to the old unconditional-spread result (no regression for armed devices).
- `SA_HIGH_PRESET.hardware.laser` (disarmed, no override) → keeps prior settings instead of the preset's 40Hz/5000ms.

All four assertions passed. I was not able to do a full browser click-through in this sandbox — no `chromium-cli` and no network access to install Playwright/a browser binary — so this is a logic-level verification against the real preset data rather than a UI screenshot; flagging that gap rather than claiming I clicked through it.

## Risk / not changed

- No change to live command-sending (step 2 of `applySessionPreset`) — see above.
- No change to `SessionPresetCard`'s display or arm-toggle affordance — it already read `preset.hardware` directly, independent of this merge step.
- No change to any preset data file — only the merge logic that consumes it.
- Behavior for every *armed* device, in every preset, is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01346kvZH7L5ruXUGec8Rvz1