### PR TITLE
docs: Add avrdude install instructions for source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ cd labrynth
 pip install -e ".[cli]"
 ```
 
+Installer builds bundle `avrdude` for firmware uploads — nothing else to install. Running from source needs it on `PATH`:
+
+| Platform | Install |
+|---|---|
+| Linux | `sudo apt-get install avrdude` (Debian/Ubuntu), or your distro's package manager |
+| macOS | `brew install avrdude` |
+| Windows | [avrdude releases](https://github.com/avrdudes/avrdude/releases), or `choco install avrdude` |
+
 Reference documentation lives in [`docs/`](docs/) ([issue reporting](docs/issue-reporting.md)); [CONTRIBUTING.md](CONTRIBUTING.md) covers the branching and versioning workflow, and [RELEASING.md](RELEASING.md) covers release channels and tagging.
 
 ---


### PR DESCRIPTION
## Problem

`labrynth/README.md` has no avrdude installation guidance for developers running from source.

## Root cause

`grep -ic avrdude README.md` on `main` returns `0`. The "Getting Started" section covers `git clone` + `pip install -e ".[cli]"` but never mentions that the app shells out to `avrdude` for firmware uploads, or how to get it on `PATH` when not using a prebuilt installer.

## What changed

`README.md` — added a short table right after the source-install snippet in **Getting Started**, covering Linux (`apt-get`), macOS (`brew`), and Windows (avrdude releases / `choco`). Explicitly states installer builds already bundle avrdude and need nothing extra, so source-only users don't install it needlessly. Matches the existing Download section's table style; no restructuring elsewhere in the document.

## Acceptance criteria (Otis-Lab-MUSC/labrynth#26)

- **AC4** — ✅ this PR: README now documents avrdude install for non-installer (dev) users, Linux/macOS/Windows.
- AC1 (avrdude bundled) / AC2 (`labrynth.spec` bundles binary + companion libs + `avrdude.conf`) — already satisfied on `main`, not touched here.
- AC3 (upload API returns 4xx instead of 500 when avrdude is absent at runtime) — covered by the sibling reacher PR: Otis-Lab-MUSC/reacher#64.

## Verification

Baseline (unmodified `main`, commit `d2028a3`):
```
$ cd web && npm run lint
✖ 34 problems (0 errors, 34 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option.

$ npx tsc -b
(no output — clean)
```
34 warnings / 0 errors matches CLAUDE.md's documented baseline ("the tree currently carries 34 pre-existing react-hooks warnings but 0 errors").

After this change (README-only, `web/` untouched):
```
$ cd web && npm run lint
✖ 34 problems (0 errors, 34 warnings)   # identical

$ npx tsc -b
(no output — clean)
```

## Risk / not changed

- Docs-only change; no code, no `web/` files touched.
- Document structure/voice unchanged elsewhere.

Related to Otis-Lab-MUSC/labrynth#26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QywcTx5yKvRV6BeKUupVvL