### PR TITLE
feat(hardware): per-trial-type laser pulse override UI for Pavlovian (#34)

### DIFF
--- a/web/src/components/hardware/LaserControl.tsx
+++ b/web/src/components/hardware/LaserControl.tsx
@@ -17,7 +17,11 @@ export function LaserControl({ sessionId, paradigm }: Props) {
 
   if (!laser) return null;
 
-  const { armed, frequency, duration, mode, phase, contingency, onsetDelay } = laser;
+  const {
+    armed, frequency, duration, mode, phase, contingency, onsetDelay,
+    csPlusFrequency, csPlusDuration, csPlusDelay,
+    csMinusFrequency, csMinusDuration, csMinusDelay,
+  } = laser;
   // vi/omission firmware has no LASER_LEVER_FILTER, so command 685 falls through
   // to `default:` and the *previous* contingency stays in force — selecting "LH"
   // there silently keeps stimulating the other lever. Gate derived from reacher's
@@ -91,6 +95,42 @@ export function LaserControl({ sessionId, paradigm }: Props) {
                   onClick={() => { send(695); updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, phase: "cue" } })); }}
                   className={`btn-sm ${phase === "cue" ? "bg-purple-600" : "bg-purple-600/40"} text-white`}
                 >Cue</button>
+              </div>
+              <div className="border-t border-theme-text/10 pt-2 mt-1 space-y-2">
+                <div className="text-xs font-medium uppercase tracking-wide text-theme-text/60"
+                  title="Optional — leave unset to keep using the shared Freq/Dur/Delay fields below for that trial type">
+                  Per-Trial Pulse Override
+                </div>
+                {(
+                  [
+                    { label: "CS+", freq: csPlusFrequency, dur: csPlusDuration, delay: csPlusDelay, freqCmd: 696, durCmd: 697, delayCmd: 698, key: "csPlus" as const },
+                    { label: "CS-", freq: csMinusFrequency, dur: csMinusDuration, delay: csMinusDelay, freqCmd: 699, durCmd: 700, delayCmd: 701, key: "csMinus" as const },
+                  ] as const
+                ).map(({ label, freq, dur, delay, freqCmd, durCmd, delayCmd, key }) => {
+                  const effFreq = freq ?? frequency;
+                  const effDur = dur ?? duration;
+                  const effDelay = delay ?? onsetDelay;
+                  return (
+                    <div key={key} className="flex flex-wrap items-center gap-2">
+                      <span className="text-xs text-theme-text/60 w-8">{label}</span>
+                      <input type="number" value={effFreq} min={1} max={65535}
+                        onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, [`${key}Frequency`]: +e.target.value } }))}
+                        className="w-16 input-base" title={`${label} frequency (Hz)`} />
+                      <button onClick={() => send(freqCmd, effFreq)} disabled={effFreq < 1 || effFreq > 65535}
+                        className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50">Set</button>
+                      <input type="number" value={effDur} min={1} max={600000}
+                        onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, [`${key}Duration`]: +e.target.value } }))}
+                        className="w-20 input-base" title={`${label} duration (ms)`} />
+                      <button onClick={() => send(durCmd, effDur)} disabled={effDur < 1 || effDur > 600000}
+                        className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50">Set</button>
+                      <input type="number" value={effDelay} min={0} max={delayMax}
+                        onChange={(e) => updateHardwareUi(sessionId, (prev) => ({ laser: { ...prev.laser, [`${key}Delay`]: Math.min(Math.max(0, +e.target.value), delayMax) } }))}
+                        className="w-20 input-base" title={`${label} onset delay (ms)`} />
+                      <button onClick={() => send(delayCmd, effDelay)} disabled={effDelay < 0 || effDelay > delayMax}
+                        className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50">Set</button>
+                    </div>
+                  );
+                })}
               </div>
             </>
           )}

--- a/web/src/components/hardware/LaserControl.tsx
+++ b/web/src/components/hardware/LaserControl.tsx
@@ -103,10 +103,10 @@ export function LaserControl({ sessionId, paradigm }: Props) {
                 </div>
                 {(
                   [
-                    { label: "CS+", freq: csPlusFrequency, dur: csPlusDuration, delay: csPlusDelay, freqCmd: 696, durCmd: 697, delayCmd: 698, key: "csPlus" as const },
-                    { label: "CS-", freq: csMinusFrequency, dur: csMinusDuration, delay: csMinusDelay, freqCmd: 699, durCmd: 700, delayCmd: 701, key: "csMinus" as const },
+                    { label: "CS+", freq: csPlusFrequency, dur: csPlusDuration, delay: csPlusDelay, freqCmd: 696, durCmd: 697, delayCmd: 698, clearCmd: 702, key: "csPlus" as const },
+                    { label: "CS-", freq: csMinusFrequency, dur: csMinusDuration, delay: csMinusDelay, freqCmd: 699, durCmd: 700, delayCmd: 701, clearCmd: 703, key: "csMinus" as const },
                   ] as const
-                ).map(({ label, freq, dur, delay, freqCmd, durCmd, delayCmd, key }) => {
+                ).map(({ label, freq, dur, delay, freqCmd, durCmd, delayCmd, clearCmd, key }) => {
                   const effFreq = freq ?? frequency;
                   const effDur = dur ?? duration;
                   const effDelay = delay ?? onsetDelay;
@@ -128,6 +128,21 @@ export function LaserControl({ sessionId, paradigm }: Props) {
                         className="w-20 input-base" title={`${label} onset delay (ms)`} />
                       <button onClick={() => send(delayCmd, effDelay)} disabled={effDelay < 0 || effDelay > delayMax}
                         className="btn-sm bg-accent text-accent-contrast text-xs disabled:opacity-50">Set</button>
+                      <button
+                        onClick={() => {
+                          send(clearCmd);
+                          updateHardwareUi(sessionId, (prev) => {
+                            const next = { ...prev.laser };
+                            delete (next as Record<string, unknown>)[`${key}Frequency`];
+                            delete (next as Record<string, unknown>)[`${key}Duration`];
+                            delete (next as Record<string, unknown>)[`${key}Delay`];
+                            return { laser: next };
+                          });
+                        }}
+                        disabled={freq === undefined && dur === undefined && delay === undefined}
+                        title={`Revert ${label} to the shared Freq/Dur/Delay fields below`}
+                        className="btn-sm bg-theme-text/10 text-theme-text/70 text-xs hover:bg-theme-text/20 disabled:opacity-50"
+                      >Clear</button>
                     </div>
                   );
                 })}

--- a/web/src/components/program/devicePresets.ts
+++ b/web/src/components/program/devicePresets.ts
@@ -39,7 +39,13 @@ export const PRESET_COMMAND_MAP: Record<string, { arm: number; disarm: number; p
   secondaryCue:  { arm: 311,  disarm: 310,  params: { frequency: 381, duration: 382, leverFilter: 388 } },
   primaryPump:   { arm: 401,  disarm: 400,  params: { duration: 472,  leverFilter: 478, delay: 477 } },
   secondaryPump: { arm: 411,  disarm: 410,  params: { duration: 482,  leverFilter: 488, delay: 487 } },
-  laser:         { arm: 601,  disarm: 600,  params: { frequency: 671, duration: 672, delay: 673 } },
+  laser:         { arm: 601,  disarm: 600,  params: {
+    frequency: 671, duration: 672, delay: 673,
+    // Pavlovian-only per-trial-type overrides (#34) — no-ops for other paradigms
+    // since their hardware.laser never sets these keys.
+    csPlusFrequency: 696, csPlusDuration: 697, csPlusDelay: 698,
+    csMinusFrequency: 699, csMinusDuration: 700, csMinusDelay: 701,
+  } },
   lickCircuit:   { arm: 501,  disarm: 500 },
   microscope:    { arm: 901,  disarm: 900 },
   slm:           { arm: 1101, disarm: 1100, params: { laserFrequency: 1102, laserDuration: 1103 } },

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -53,6 +53,14 @@ export interface LaserUiState extends DeviceArmState {
   phase?: "reward" | "cue";  // Pavlovian only — which trial phase triggers laser
   contingency: "any" | "rh" | "lh" | "independent";  // operant lever routing (#67)
   onsetDelay: number;  // ms from trigger to laser onset (#67/#69)
+  // Pavlovian only — per-trial-type pulse overrides (commands 696-701, #34).
+  // Undefined/unset means that trial type falls back to frequency/duration/onsetDelay above.
+  csPlusFrequency?: number;
+  csPlusDuration?: number;
+  csPlusDelay?: number;
+  csMinusFrequency?: number;
+  csMinusDuration?: number;
+  csMinusDelay?: number;
 }
 
 export interface MicroscopeUiState extends DeviceArmState {


### PR DESCRIPTION
Closes Otis-Lab-MUSC/labrynth#34

> **This merge closes #34, but the firmware half is not yet bench-validated.** #34's acceptance criteria include firmware behavior (the trial filter, phase selection, and per-trial pulse override implemented across this PR and the paired reacher#66). reacher#66 requires a firmware rebuild (`bash firmware/compile.sh`) and on-rig validation on a real Mega 2560 before it can merge — neither has happened yet. A closed #34 at that point means "the UI and the firmware source are in, three rounds of cross-review are resolved" — it does not yet mean "verified working on hardware." If reacher#66 surfaces a defect during rig validation that isn't a same-day fix, reopen #34 rather than filing a new issue for the same feature.

## Problem

#34 asks for Pavlovian laser flexibility: a trial-filter selector (CS+/CS-/both) and a per-trial-type pulse pattern (onset, duration, frequency).

Before writing anything, I checked the current state of `LaserControl.tsx`, `devicePresets.ts`, `ProgramPanel.tsx`, and `SessionStartModal.tsx`. The trial-filter and phase-selection halves of this issue were **already fully implemented**:
- `LaserControl.tsx:69-94` — "Trial Filter" (CS+/CS-/Both) and "Phase" (Reward/Cue) button rows, dispatching commands 691-695
- `devicePresets.ts:27-33` — `LASER_MODE_COMMANDS`/`PAV_LASER_PHASE_COMMANDS`
- `ProgramPanel.tsx:154-179`, `ConfigurationPanel.tsx`, `SessionStartModal.tsx:167-180` — mode/phase already dispatched on preset apply and session start, satisfying "settings persist in session preset and are replayed on session load" for those two controls

The one **unmet** acceptance criterion was: *"Laser pulse onset, duration, and frequency configurable per trial type."* There was one shared Freq/Dur/Delay control (commands 671/672/673) applied uniformly regardless of trial type. This PR adds the UI for the six new Pavlovian-only firmware commands (696-703) added in the paired reacher PR that let CS+ and CS- override these independently.

Paired with reacher PR: Otis-Lab-MUSC/reacher#66 (firmware source + `commands.py` mirror — **not yet merged; requires a firmware rebuild + rig validation before it can be**, see that PR's Risk section).

## What changed

- **`web/src/types/index.ts`** (`LaserUiState`, line 49) — 6 new optional fields: `csPlusFrequency`, `csPlusDuration`, `csPlusDelay`, `csMinusFrequency`, `csMinusDuration`, `csMinusDelay`. Optional and undefined-by-default, so non-Pavlovian code paths are unaffected.
- **`web/src/components/program/devicePresets.ts`** (`PRESET_COMMAND_MAP.laser.params`) — maps the six new fields to commands 696-703. This is the *only* wiring needed for persistence/replay: `ProgramPanel.tsx`'s `applySessionPreset`/`applyDevicePreset` and `SessionStartModal.tsx` already iterate `mapping.params` generically and send whatever keys are present in `hardware.laser`, and `buildPresetFromSession` (`deviceMetadata.ts:47`) already captures the full `hardwareUi.laser` object verbatim when saving a custom preset. No changes needed to any of those three files.
- **`web/src/components/hardware/LaserControl.tsx`** — adds a "Per-Trial Pulse Override" section, shown alongside Trial Filter/Phase for trial-paired (non-independent) Pavlovian modes. Three fields per trial type (CS+, CS-), each with its own Set button, matching the existing Freq/Dur/Delay control pattern at the bottom of the card, plus a Clear button per trial type (see below). Inputs default to displaying the shared `frequency`/`duration`/`onsetDelay` values (`effFreq = csPlusFrequency ?? frequency`, etc.) until the user explicitly sets an override, so the field visibly shows what firmware will actually use even before any override exists.

## Fixed after cross-review: added Clear button (commands 702/703)

Two reviewers found real defects in the paired reacher PR's first draft — an override that leaked across unrelated later sessions, and per-trial-type granularity that silently pinned unrelated fields to compile-time defaults instead of the live shared laser value. Neither required a change on this side (this UI's Set-button semantics were already what the fixed firmware now actually does — `effFreq ?? frequency` already implied "unset falls back to the live shared value," which is exactly what the corrected `ResolveLaserPulse` now provides). The one thing this PR did need: the fixed firmware added explicit clear commands (702/703 — `PAV_LASER_CS_PLUS_CLEAR_OVERRIDE`/`PAV_LASER_CS_MINUS_CLEAR_OVERRIDE`) since there was previously no way back to "use shared value" short of a reboot. Added a Clear button next to each trial type's three Set buttons, disabled when no override is set, that sends the clear command and resets the corresponding `hardwareUi.laser` fields to `undefined` so the display immediately reflects the fallback.

## Acceptance criteria (from #34)

- [x] Pavlovian hardware config exposes a trial-filter selector for the laser (CS+, CS−, both) — **pre-existing**
- [x] Laser pulse onset, duration, and frequency configurable per trial type — **this PR** (UI; firmware in the paired reacher PR)
- [x] Firmware correctly arms/disarms laser based on current trial type at trial start — **pre-existing** firmware (`ShouldFireLaser` in `PavlovianScheduler.cpp`)
- [x] Settings persist in session preset and are replayed on session load — covered by the existing generic `PRESET_COMMAND_MAP` pipeline, confirmed by inspection (see "What changed" above); no dedicated preset entries were added for the new fields since they're optional overrides, not required session state
- [x] Other paradigms (FR, PR, VI, Omission) are not regressed — the new UI section and fields are gated behind `isPavlovian`; `LaserUiState`'s new fields are optional and never populated for other paradigms

## Verification

Baseline (unmodified `main`, commit `d2028a3b1`):
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)
$ npx tsc -b
(no output — clean)
```

Post-change (including the Clear-button fix commit):
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)
$ npx tsc -b
(no output — clean)
```
Same 0 errors / 34 pre-existing warnings as baseline (CLAUDE.md documents this count) — no regressions, no new warnings introduced.

No test framework exists in this repo by design (per CLAUDE.md); verified by reading through the full preset-apply and session-start dispatch paths listed above to confirm the new fields flow through with zero additional wiring, and by cross-checking against reacher's `test_command_parity.py`/`test_firmware_parity.py` (52 passed) and `test_frontend_parity.py` (15 passed) in the paired PR.

## Risk / not changed

- This PR is UI-only against **command codes that do not yet exist on any shipped firmware build** — the paired reacher PR adds the firmware source but explicitly does not rebuild `src/reacher/hex/**` (hard constraint: no `compile.sh`, no committed hex changes). Until reacher's hex is rebuilt and the labrynth `reacher2p` pin is bumped to a build that includes these commands, sending 696-703 from this UI to a real rig will hit whatever a Pavlovian sketch without these commands does with an unrecognized code (a level-006 "unknown command" per the existing `default: logUnknownCommand(command);` case) — i.e. **harmless no-op, not silent misbehavior**, but this UI should not be considered functional until the paired firmware PR is merged, rebuilt, and the version pin is bumped.
- `hardwareSummary.ts`'s monitor-panel laser summary was not extended to show per-trial pulse overrides — it currently only summarizes phase/lever-filter, not frequency/duration, so this is consistent with what was already shown, not a regression, but a per-type override is not visible outside the Hardware panel itself. Left out of scope to keep this PR reviewable; flag if the owner wants it.
- No changes to `pavlovianPresets.ts` built-in presets (Acquisition/Reversal) — the six new fields are optional overrides with no default worth baking into a built-in preset; a user can set and save them into a custom preset via "Save Current Config as Preset".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KSKVK4UrFiKXSjmwMMfMX