### PR TITLE
feat: Add human-readable interface changelog to the About dialog

### DIFF
--- a/web/src/components/layout/AboutModal.tsx
+++ b/web/src/components/layout/AboutModal.tsx
@@ -7,6 +7,7 @@ import { useUpdateStore } from "../../store/useUpdateStore";
 import { getLocalClient } from "../../api/client";
 import { downloadDiagnostics } from "../../logging";
 import { useReportStore } from "../../store/useReportStore";
+import { INTERFACE_CHANGELOG } from "../../lib/interfaceChangelog";
 
 interface AboutModalProps {
   open: boolean;
@@ -107,6 +108,26 @@ export function AboutModal({ open, onClose }: AboutModalProps) {
             </tr>
           </tbody>
         </table>
+
+        {INTERFACE_CHANGELOG.length > 0 && (
+          <div className="mb-4">
+            <p className="mb-2 text-sm font-medium text-theme-text">What's new</p>
+            <div className="max-h-40 space-y-3 overflow-y-auto rounded border border-theme-border px-3 py-2.5 text-xs text-theme-text/70">
+              {INTERFACE_CHANGELOG.map((entry) => (
+                <div key={entry.version}>
+                  <p className="mb-1 font-mono text-theme-text/50">
+                    v{entry.version} — {entry.date}
+                  </p>
+                  <ul className="list-disc space-y-0.5 pl-4">
+                    {entry.highlights.map((highlight) => (
+                      <li key={highlight}>{highlight}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {update ? (
           <div className="mb-4 rounded border border-accent/30 bg-accent/10 px-3 py-2.5">

--- a/web/src/lib/interfaceChangelog.ts
+++ b/web/src/lib/interfaceChangelog.ts
@@ -1,0 +1,45 @@
+/**
+ * Human-facing release notes shown in the About dialog.
+ *
+ * Audience is the bench scientist running the rig, not a developer — entries
+ * describe what changed about *using the app*, in plain language, not what
+ * changed in the code. This is hand-written and deliberately separate from
+ * the root CHANGELOG.md (an engineering changelog: file names, PR/issue
+ * links, refactors, CI). Add an entry here only when a release has a
+ * user-visible change worth telling a researcher about; skip internal-only
+ * releases rather than translating every CHANGELOG.md line.
+ */
+
+export interface InterfaceChangelogEntry {
+  version: string;
+  date: string; // YYYY-MM-DD
+  highlights: string[];
+}
+
+// Newest first.
+export const INTERFACE_CHANGELOG: InterfaceChangelogEntry[] = [
+  {
+    version: "3.0.1-alpha.21",
+    date: "2026-09-01",
+    highlights: [
+      "On VI and Omission rigs, choosing \"LH lever\" for the laser now actually switches it — previously the display updated but the rig kept stimulating the old lever.",
+      "Infusion counts no longer reset to zero if your session reconnects mid-run.",
+      "Lick-circuit pin assignments now display correctly after a reconnect.",
+    ],
+  },
+  {
+    version: "3.0.1-alpha.12",
+    date: "2026-07-27",
+    highlights: [
+      "fr_lite sessions now have ready-made presets (High/Mid/Low/Extinction), matching what was already available for FR.",
+    ],
+  },
+  {
+    version: "3.0.1-alpha.11",
+    date: "2026-07-24",
+    highlights: [
+      "FR self-administration presets now deliver the reward right as the cue tone ends, as originally designed — previously it fired at the same instant the cue started.",
+      "The Two-Photon Devices section is now hidden for UNO-based rigs, since that hardware doesn't support it.",
+    ],
+  },
+];

--- a/web/src/lib/interfaceChangelog.ts
+++ b/web/src/lib/interfaceChangelog.ts
@@ -22,7 +22,7 @@ export const INTERFACE_CHANGELOG: InterfaceChangelogEntry[] = [
     version: "3.0.1-alpha.21",
     date: "2026-09-01",
     highlights: [
-      "On VI and Omission rigs, choosing \"LH lever\" for the laser now actually switches it — previously the display updated but the rig kept stimulating the old lever.",
+      "On VI and Omission rigs, the \"LH lever\" laser option is now disabled, with the reason shown, instead of silently doing nothing — that firmware ignores the command and keeps stimulating whichever lever was previously set. If you were selecting LH on a VI or Omission rig before this update, check your session data: the laser may have been stimulating on RH presses the whole time.",
       "Infusion counts no longer reset to zero if your session reconnects mid-run.",
       "Lick-circuit pin assignments now display correctly after a reconnect.",
     ],
@@ -31,7 +31,7 @@ export const INTERFACE_CHANGELOG: InterfaceChangelogEntry[] = [
     version: "3.0.1-alpha.12",
     date: "2026-07-27",
     highlights: [
-      "fr_lite sessions now have ready-made presets (High/Mid/Low/Extinction), matching what was already available for FR.",
+      "fr_lite sessions now actually work — every command used to be rejected by the backend. They also have ready-made presets (High/Mid/Low/Extinction), matching what was already available for FR.",
     ],
   },
   {


### PR DESCRIPTION
## Problem

No changelog surface exists for the app's actual audience — bench scientists running experiments, not developers. The root `CHANGELOG.md` is an engineering changelog (file names, PR/issue links, refactors, CI) and is the wrong thing to show someone deciding whether to re-flash a rig or wondering why a control behaves differently than they remember.

## Design decisions

**Integration point — `AboutModal.tsx`.** It's already the app's version-info surface: shows `v{__APP_VERSION__}` and the backend version in a table, and links to release notes for an *available update*. A "what's new" section for the *currently installed* version belongs directly under that table — same place someone checking "what version am I on" would look for "what changed." Chose an inline section over a second modal: the codebase's existing pattern for a second dialog (`ReportIssueModal`) is a full form-driven modal launched via a store, which is more machinery than a handful of bullet points warrants, and stacking modals isn't a pattern used elsewhere here.

**Content source — new hand-written file, not derived from `CHANGELOG.md`.** `web/src/lib/interfaceChangelog.ts` is a small static array of `{version, date, highlights[]}`, imported at build time. Not derived automatically from `CHANGELOG.md` (wrong voice/audience — translating "Frontend: `EventTimeline` device tables reconciled against the namespaces reacher actually emits" into something a researcher cares about is a judgment call, not a mechanical transform) and not scraped from git log at runtime (per standing instructions, and it would leak internal commit noise anyway). It's maintained the same way `CHANGELOG.md` itself is: by hand, at release time, by whoever is best placed to say what a researcher should know changed.

## What changed

- `web/src/lib/interfaceChangelog.ts` (new) — `INTERFACE_CHANGELOG`, seeded with 3 entries translated from the 3 most recent `CHANGELOG.md` releases that had a user-visible change (v3.0.1-alpha.21, -alpha.12, -alpha.11). Releases that were purely internal (tooling, CI) were skipped rather than translated wholesale — that's the intended maintenance model, not an oversight.
- `web/src/components/layout/AboutModal.tsx` — renders a "What's new" section (scrollable, `max-h-40`, matches the modal's existing border/spacing conventions) directly under the version table.

## Acceptance criteria (Otis-Lab-MUSC/labrynth#20)

- A changelog surface exists, reachable from the app (About dialog).
- Entries describe app behavior in plain language, not code changes.
- Content is curated, not auto-generated from `CHANGELOG.md` or git history.

## Verification

Baseline (unmodified `main`, commit `d2028a3b1` — same commit this branch is cut from, established earlier this session for a sibling PR against this same worktree):
```
$ cd web && npm run lint
✖ 34 problems (0 errors, 34 warnings)

$ npx tsc -b
(no output — clean)
```

After this change:
```
$ cd web && npm run lint
✖ 34 problems (0 errors, 34 warnings)   # identical — no new warnings from the new code

$ npx tsc -b
(no output — clean)
```

**Browser verification** (this repo has no test framework by design — see CLAUDE.md): started the Vite dev server, drove headless Chromium via Playwright, dismissed the welcome-tour overlay, clicked the About button, and screenshotted the rendered modal. The "What's new" section renders with correct styling and text, matches the surrounding card's border/spacing conventions, and scrolls independently when content overflows. No new console errors — the two present are the pre-existing health-check 404 from no backend running in this dev-only check, unrelated to this change.

## Risk / not changed

- No `CHANGELOG.md` changes, no version-bump tooling changes.
- No new store, no new modal — extends the existing `AboutModal` in place.
- Content is static/bundled; no runtime fetch, no git-log scraping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QywcTx5yKvRV6BeKUupVvL