### PR TITLE
fix: reconcile behavior/frame/slm streams independently on WS reconnect

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -293,12 +293,19 @@ export class MachineApiClient {
     this.request<{ frames: unknown[]; count: number }>(`/data/${id}/frames`);
   getSlmEvents = (id: string) =>
     this.request<{ slm: number[]; count: number }>(`/data/${id}/slm`);
-  /** Issue #100: one consistent snapshot of all three streams, for WS-reconnect recovery. */
+  /**
+   * Issue #100: a snapshot of all three streams, for WS-reconnect recovery.
+   * NOT symmetric — `behavior` is current-segment-only (split_segment()
+   * clears it every split), `frames`/`slm` are whole-session. `segment_number`
+   * (0 if no split has occurred) tells the caller which segment `behavior`
+   * belongs to, so a client that missed a live "split" message can tell.
+   */
   getRecovery = (id: string) =>
     this.request<{
       behavior: { data: Array<Record<string, unknown>>; total: number };
       frames: { frames: number[]; count: number };
       slm: { slm: number[]; count: number };
+      segment_number: number;
     }>(`/data/${id}/recovery`);
   exportZip = async (
     id: string,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -293,6 +293,13 @@ export class MachineApiClient {
     this.request<{ frames: unknown[]; count: number }>(`/data/${id}/frames`);
   getSlmEvents = (id: string) =>
     this.request<{ slm: number[]; count: number }>(`/data/${id}/slm`);
+  /** Issue #100: one consistent snapshot of all three streams, for WS-reconnect recovery. */
+  getRecovery = (id: string) =>
+    this.request<{
+      behavior: { data: Array<Record<string, unknown>>; total: number };
+      frames: { frames: number[]; count: number };
+      slm: { slm: number[]; count: number };
+    }>(`/data/${id}/recovery`);
   exportZip = async (
     id: string,
     body: {

--- a/web/src/hooks/useSessionWebSockets.ts
+++ b/web/src/hooks/useSessionWebSockets.ts
@@ -259,8 +259,31 @@ async function recoverMissedEvents(sessionId: string) {
     // transient race, a permanent loss, since the old `/behavior` endpoint
     // has no way to give SLM ticks back. Each stream is now reconciled
     // against its own prior count instead.
-    const { behavior, frames, slm } = await client.getRecovery(sessionId);
+    const { behavior, frames, slm, segment_number } = await client.getRecovery(sessionId);
     sess = useSessionStore.getState().sessions.get(sessionId) ?? sess;
+
+    // Cross-review finding on #70/#126: split_segment() exports and clears
+    // the backend's behavior_data on every split but leaves frame_data/
+    // slm_data alone, so `behavior.data` is current-segment-only while
+    // frames/slm are whole-session. If this client missed the live "split"
+    // WS message while disconnected, `sess.segmentNumber` is stale and local
+    // `behaviorData` still holds the now-closed segment's events — merging
+    // it against the new segment's snapshot below would silently destroy
+    // that data instead of retiring it the way a live split does. Catch up
+    // via the same handler a live "split" message uses, which rolls the
+    // stale segment's counters into cumulative* and resets `behaviorData`
+    // for the new segment, so nothing is lost — only correctly archived,
+    // same as any other split. (A disconnect spanning *multiple* splits
+    // still converges structurally — segmentNumber jumps straight to
+    // current, behaviorData resets clean — but only rolls the last-known
+    // local counters into cumulative once; any fully-missed intermediate
+    // segment's derived counts aren't separately re-added here, though
+    // they're safely on disk as that segment's own exported CSV and in the
+    // backend's own get_total_* accessors.)
+    if (segment_number > sess.segmentNumber) {
+      useSessionStore.getState().handleSplit(sessionId, segment_number);
+      sess = useSessionStore.getState().sessions.get(sessionId) ?? sess;
+    }
 
     const localNonSlmCount = sess.behaviorData.filter((e) => e.device !== "SLM").length;
     const localSlmCount = sess.behaviorData.length - localNonSlmCount;

--- a/web/src/hooks/useSessionWebSockets.ts
+++ b/web/src/hooks/useSessionWebSockets.ts
@@ -264,9 +264,10 @@ async function recoverMissedEvents(sessionId: string) {
 
     const localNonSlmCount = sess.behaviorData.filter((e) => e.device !== "SLM").length;
     const localSlmCount = sess.behaviorData.length - localNonSlmCount;
+    const missedBehavior = Math.max(0, behavior.total - localNonSlmCount);
+    const missedSlm = Math.max(0, slm.count - localSlmCount);
     const missedFrames = Math.max(0, frames.count - sess.frameData.length);
-    const recovered =
-      Math.max(0, behavior.total - localNonSlmCount) + Math.max(0, slm.count - localSlmCount) + missedFrames;
+    const recovered = missedBehavior + missedSlm + missedFrames;
 
     if (recovered === 0) return;
 
@@ -274,22 +275,31 @@ async function recoverMissedEvents(sessionId: string) {
       useSessionStore.getState().updateState(sessionId, "running");
     }
 
-    // Both `behavior.data` and `slm.slm` are complete, authoritative
-    // snapshots (same guarantee `/behavior`'s `total` already gave for
-    // non-SLM events) — reconstructing SLM ticks as synthetic events and
-    // merging keeps EventTimeline and the "SLM FRAMES" stat (LiveStats.tsx,
-    // still keyed on `device === "SLM"` within `behaviorData`) working
-    // unchanged, while never dropping one stream's data to recover the other.
-    const slmEvents: BehaviorEvent[] = slm.slm.map((ts) => ({
-      device: "SLM",
-      event: "TIMESTAMP",
-      start_timestamp: ts,
-      end_timestamp: ts,
-    }));
-    const merged = [...(behavior.data as unknown as BehaviorEvent[]), ...slmEvents].sort(
-      (a, b) => a.start_timestamp - b.start_timestamp,
-    );
-    replaceEvents(sessionId, merged);
+    // frameData can be gated independently of the event streams below purely
+    // because it's a plain array with no derived counters — a frames-only
+    // miss has no reason to touch behaviorData at all. behaviorData can't
+    // split that cleanly: it mixes two streams (behavior + synthetic SLM) and
+    // replaceEvents recomputes derived counters (press/infusion/trial/etc.)
+    // from the full array every time, so a behavior-or-SLM miss replaces both
+    // together in one call rather than each independently.
+    if (missedBehavior > 0 || missedSlm > 0) {
+      // Both `behavior.data` and `slm.slm` are complete, authoritative
+      // snapshots (same guarantee `/behavior`'s `total` already gave for
+      // non-SLM events) — reconstructing SLM ticks as synthetic events and
+      // merging keeps EventTimeline and the "SLM FRAMES" stat (LiveStats.tsx,
+      // still keyed on `device === "SLM"` within `behaviorData`) working
+      // unchanged, while never dropping one stream's data to recover the other.
+      const slmEvents: BehaviorEvent[] = slm.slm.map((ts) => ({
+        device: "SLM",
+        event: "TIMESTAMP",
+        start_timestamp: ts,
+        end_timestamp: ts,
+      }));
+      const merged = [...(behavior.data as unknown as BehaviorEvent[]), ...slmEvents].sort(
+        (a, b) => a.start_timestamp - b.start_timestamp,
+      );
+      replaceEvents(sessionId, merged);
+    }
 
     if (missedFrames > 0) {
       useSessionStore.getState().replaceFrameData(sessionId, frames.frames);

--- a/web/src/hooks/useSessionWebSockets.ts
+++ b/web/src/hooks/useSessionWebSockets.ts
@@ -246,18 +246,56 @@ async function recoverMissedEvents(sessionId: string) {
   if (sess.state === "idle" || sess.state === "stopped") return;
 
   try {
-    const { data, total } = await client.getBehavior(sessionId);
-    if (total > sess.behaviorData.length) {
-      if (useSessionStore.getState().sessions.get(sessionId)?.state === "connected") {
-        useSessionStore.getState().updateState(sessionId, "running");
-      }
-      replaceEvents(sessionId, data as unknown as BehaviorEvent[]);
-      useLogStore.getState().pushLog(
-        "info",
-        `Recovered ${total - sess.behaviorData.length} missed events after reconnect`,
-        sessionId,
-      );
+    // Issue #100: behavior, frames, and slm are independent backend streams —
+    // `self.behavior_data` never holds SLM ticks (see reacher's
+    // `update_slm_events`), yet a live "event" WS message for an SLM tick
+    // still lands in local `behaviorData` (same as any other event). Comparing
+    // a single `total` against `behaviorData.length` was comparing counts from
+    // two different streams: it could both silently drop real missed
+    // lever/pump/etc. events (when locally-accumulated SLM ticks inflated
+    // `behaviorData.length` past a lagging `total`) and permanently wipe every
+    // SLM tick of the session on a full replace (when enough non-SLM events
+    // were missed to push `total` past that inflated length) — not a
+    // transient race, a permanent loss, since the old `/behavior` endpoint
+    // has no way to give SLM ticks back. Each stream is now reconciled
+    // against its own prior count instead.
+    const { behavior, frames, slm } = await client.getRecovery(sessionId);
+    sess = useSessionStore.getState().sessions.get(sessionId) ?? sess;
+
+    const localNonSlmCount = sess.behaviorData.filter((e) => e.device !== "SLM").length;
+    const localSlmCount = sess.behaviorData.length - localNonSlmCount;
+    const missedFrames = Math.max(0, frames.count - sess.frameData.length);
+    const recovered =
+      Math.max(0, behavior.total - localNonSlmCount) + Math.max(0, slm.count - localSlmCount) + missedFrames;
+
+    if (recovered === 0) return;
+
+    if (useSessionStore.getState().sessions.get(sessionId)?.state === "connected") {
+      useSessionStore.getState().updateState(sessionId, "running");
     }
+
+    // Both `behavior.data` and `slm.slm` are complete, authoritative
+    // snapshots (same guarantee `/behavior`'s `total` already gave for
+    // non-SLM events) — reconstructing SLM ticks as synthetic events and
+    // merging keeps EventTimeline and the "SLM FRAMES" stat (LiveStats.tsx,
+    // still keyed on `device === "SLM"` within `behaviorData`) working
+    // unchanged, while never dropping one stream's data to recover the other.
+    const slmEvents: BehaviorEvent[] = slm.slm.map((ts) => ({
+      device: "SLM",
+      event: "TIMESTAMP",
+      start_timestamp: ts,
+      end_timestamp: ts,
+    }));
+    const merged = [...(behavior.data as unknown as BehaviorEvent[]), ...slmEvents].sort(
+      (a, b) => a.start_timestamp - b.start_timestamp,
+    );
+    replaceEvents(sessionId, merged);
+
+    if (missedFrames > 0) {
+      useSessionStore.getState().replaceFrameData(sessionId, frames.frames);
+    }
+
+    useLogStore.getState().pushLog("info", `Recovered ${recovered} missed events after reconnect`, sessionId);
   } catch (err) {
     console.warn("[ReacherWS] Failed to recover missed events:", err);
   }

--- a/web/src/store/useSessionStore.ts
+++ b/web/src/store/useSessionStore.ts
@@ -19,6 +19,7 @@ interface SessionStore {
   pushEvent: (id: string, event: BehaviorEvent) => void;
   replaceEvents: (id: string, events: BehaviorEvent[]) => void;
   pushFrame: (id: string, timestamp: number) => void;
+  replaceFrameData: (id: string, frames: number[]) => void;
   setFirmwareInfo: (id: string, info: FirmwareConfig) => void;
   setUploadProgress: (id: string, percent: number, stage: string) => void;
   setPavlovianParams: (id: string, params: Record<number, number>) => void;
@@ -375,6 +376,17 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       if (!sess) return s;
       const next = new Map(s.sessions);
       next.set(id, { ...sess, frameData: [...sess.frameData, timestamp] });
+      return { sessions: next };
+    }),
+
+  // Issue #100: 2P frame ticks missed during a WS disconnect were never
+  // backfilled — unlike behaviorData, nothing called this on reconnect.
+  replaceFrameData: (id, frames) =>
+    set((s) => {
+      const sess = s.sessions.get(id);
+      if (!sess) return s;
+      const next = new Map(s.sessions);
+      next.set(id, { ...sess, frameData: frames });
       return { sessions: next };
     }),
 


### PR DESCRIPTION
Closes #100
Refs Otis-Lab-MUSC/reacher#70 (backend companion — adds the `/recovery` endpoint this consumes)

## Problem (in bench-user terms)

The live "SLM FRAMES" stat on the Session monitor can permanently drop to a lower value after a WebSocket reconnect — and it never self-corrects for the rest of the session. Reconnects happen from ordinary things: a laptop sleeping briefly, a flaky Wi-Fi hop, a proxied remote machine's relay reconnecting.

## Root cause

More precise than the issue text, since it changes what "fixed" means here — **this is a permanent loss, not a transient race that self-heals**:

- `reacher.py::update_slm_events` appends SLM ticks only to the backend's `self.slm_data`, never `self.behavior_data` — but it still does `_emit("event", {"device": "SLM", "event": "TIMESTAMP", ...})`. That live WS "event" message is handled identically to any other event (`useSessionWebSockets.ts:96`, `pushEvent`), so an SLM tick does land in the frontend's local `behaviorData` array.
- `data.py`'s `GET /behavior` returns `{data, total}` sourced purely from `self.behavior_data` — `total` never counts SLM ticks.
- `recoverMissedEvents` (`useSessionWebSockets.ts:220-264`, pre-fix) only replaced state when `total > sess.behaviorData.length`. Since local `behaviorData.length` already includes SLM ticks the backend total never counts, that comparison mixed two different streams:
  - If accumulated SLM ticks ≥ missed non-SLM events, the guard never fires — real missed lever/pump/etc. events are silently dropped.
  - If enough non-SLM events were missed to push backend `total` past that SLM-inflated local length, `replaceEvents` (`useSessionStore.ts:322`) fires and wholesale-replaces `behaviorData` with the backend's SLM-free list — every SLM tick the session had accumulated, not just ones from the disconnect window, is gone. `LiveStats.tsx:45` sources "SLM FRAMES" from exactly this `behaviorData` filter (`e.device === "SLM" && e.event === "TIMESTAMP"`), so it's directly exposed to both failure modes.
- The issue also names a related but distinct gap: 2P frame ticks (`frameData`, populated only by live `pushFrame` calls) were never touched by reconnect recovery at all — missed ticks during a disconnect were simply never backfilled (no reset, but no correction either).

## What changed

Consumes the new `GET /data/{id}/recovery` from the reacher companion PR, which bundles snapshots of all three streams in one request (also keeping the three fetches close together against live session state — see reacher#70 for why they aren't perfectly atomic). **`behavior` is current-segment-only, not whole-session — see "Cross-review round 2" below for why, and how this PR handles it.** `recoverMissedEvents` reconciles each stream against its own prior count — never one stream's count against another's:

- `behavior.total` vs. the count of non-SLM entries currently in `behaviorData`
- `slm.count` vs. the count of SLM entries currently in `behaviorData`
- `frames.count` vs. `frameData.length` (new — this stream was never reconciled before)

On a mismatch, SLM ticks are reconstructed as synthetic `BehaviorEvent`s (`{device: "SLM", event: "TIMESTAMP", start_timestamp, end_timestamp}`) from the backend's authoritative `slm.slm` array and merged with the backend's authoritative non-SLM `behavior.data`, sorted by timestamp, then passed to `replaceEvents` in one call — so `EventTimeline` and the "SLM FRAMES" stat keep reading `behaviorData` exactly as before; no per-device split of frontend state, only the recovery/comparison logic changed. `frameData` gets a new `replaceFrameData` store action for the same full-authoritative-replace treatment.

`replaceEvents(sessionId, merged)` only runs when `behavior.total` or `slm.count` actually exceeds the local count — a frames-only miss (behavior and SLM both already caught up) no longer rewrites `behaviorData` for nothing. `replaceFrameData` keeps its own independent `missedFrames > 0` gate; the two aren't symmetric on purpose: `frameData` is a plain array with no derived counters, so gating it separately is a pure optimization with no correctness implication, whereas `behaviorData` mixes two streams (behavior + synthetic SLM) and `replaceEvents` recomputes derived counters (press/infusion/trial/etc.) from the whole array every time it runs — it can't be split as cleanly, so a behavior-or-SLM miss replaces both together in one call.

| File | Change |
|---|---|
| `web/src/api/client.ts` | New `getRecovery(id)` on `MachineApiClient`, hitting `/data/{id}/recovery` |
| `web/src/store/useSessionStore.ts` | New `replaceFrameData` action (mirrors `replaceEvents`, no derived counters to recompute) |
| `web/src/hooks/useSessionWebSockets.ts` | `recoverMissedEvents` rewritten to fetch the unified endpoint and reconcile per-stream instead of the old cross-stream `total` vs. `behaviorData.length` guard; detects a missed split via `segment_number` and catches up through `handleSplit()` before merging |

## Acceptance criteria (from #100 / owner's scoping decisions)

- [x] Root cause pinned down precisely, citing `data.py`, `useSessionWebSockets.ts:220-264`, `reacher.py::update_slm_events`, `LiveStats.tsx:45` — see above
- [x] Fix lives behind a backend endpoint change (owner's decision, option 2) rather than folding SLM into `behavior_data` — see reacher#70
- [x] The `total`-vs-`behaviorData.length` comparison does not survive in any form — replaced by three independent per-stream comparisons
- [x] Covers the related 2P-frames gap too, not just SLM — `frameData` is now backfilled on reconnect for the first time
- [x] No test framework exists in this repo by design (per `CLAUDE.md`) — verified via `npm run lint` + `npx tsc -b` instead, matching repo convention
- [x] After a split, recovery must never remove a locally-held behavior event (owner's round-2 invariant) — see "Cross-review round 2" below

## Verification

This repo has no test framework (deliberate, see `CLAUDE.md`) — verification is lint + typecheck, baseline established on unmodified `main` (commit `d2028a3b1`) before making any change:

Baseline:
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)

$ npx tsc -b
(no output — clean)
```

After this change:
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)

$ npx tsc -b
(no output — clean)
```

Identical warning count (34, all pre-existing per `CLAUDE.md`'s documented baseline), zero errors either run, `tsc -b` clean both times. No new warnings introduced.

## Risk / not changed

- `behavior_data` on the backend, and the existing `/behavior`, `/frames`, `/slm` endpoints, are untouched (see reacher#70) — no export blast radius.
- `EventTimeline.tsx` and `LiveStats.tsx` are unchanged — SLM ticks still live inside `behaviorData` for display purposes; only how recovery reconciles and rebuilds that array changed.
- Demo mode is unaffected: demo-prefixed session IDs are filtered out of the real-WS session set before `recoverMissedEvents` can ever run (`useSessionWebSockets.ts:280`), so `getRecovery` is unreachable in demo mode and needs no mock.
- Not addressed: any UI indication that a recovery/backfill happened beyond the existing "Recovered N missed events" log line (unchanged mechanism, now covering three streams instead of one).
- **Known, documented, not fixed — a narrow live/recovery replace race.** `ReacherWebSocket.connect()` (`websocket.ts:129-145`) wires `onmessage` before the socket finishes connecting, so a live event can arrive via `pushEvent` concurrently with the `/recovery` round trip. `replaceEvents` does a wholesale replace with no dedup, and `BehaviorEvent` carries no id/sequence number to reconcile against, so a live event that lands locally during the fetch and postdates the snapshot gets discarded by the replace. **This is not a regression** — the prior code had the identical fetch → replace shape and the same round-trip window; re-reading `sess` fresh right before building `merged` makes the recovered *count* accurate (an improvement over the old code, which used the stale `sess` captured before the fetch), but the *replace* itself still only reflects the network snapshot. Real, narrow, low-probability. A proper fix needs event identity to dedup against — a bigger contract change (touching the WS event schema and the kernel's emit path) than this issue warrants; documenting instead of fixing.

## Cross-review

Independently verified clean: the synthetic SLM event shape is byte-identical to the live emission at `reacher.py:932-937` (`update_slm_events`), so `LiveStats` and `EventTimeline` cannot distinguish a recovered tick from a live one; the merge sort is a standard stable numeric comparator with nothing downstream depending on tie order; and keeping SLM inside `behaviorData` (rather than the already-scaffolded-but-dead `session.slmData` field) is correct — `MonitorPanel.tsx:242` and `LiveStats.tsx:44-46` both read `behaviorData`, and `slmData` is genuinely dead (initialized in five places in `useSessionStore.ts`, never appended to or read anywhere else in `web/src`).

## Cross-review round 2: a missed split could silently destroy pre-split behavior data

Round 1 missed that `behavior` is current-segment-only (see reacher#70's "Cross-review round 2" for the full root cause: `split_segment()` clears `behavior_data` every split but leaves `frame_data`/`slm_data` alone). The consequence here: `replaceEvents(sessionId, merged)` was replacing live `behaviorData` — which holds the *whole session* locally, since nothing client-side ever clears it except a live "split" WS message via `handleSplit` — with (current-segment-only `behavior.data`) + (whole-session SLM). If this client's WebSocket was down across the moment a split happened, it never received that "split" message, `sess.segmentNumber` stayed stale, and the very next reconnect's recovery would wholesale-replace `behaviorData` with just the new segment's events — silently dropping every pre-split lever/pump/lick event from the live UI, deterministically, on every post-split-while-disconnected reconnect (not just on a count-mismatch direction the way the round-1 bug was).

The owner's invariant: **after a split, recovery must never remove a locally-held behavior event.** Reading the segment CSVs back or keeping a cumulative in-memory event list were both rejected on the backend (see reacher#70) as disproportionate to a reconnect bug, so the fix lives entirely here: `recoverMissedEvents` now compares reacher's new `segment_number` against the locally-known `sess.segmentNumber`. If the backend is ahead, this client missed a live split — it catches up through the exact same `handleSplit()` action a live "split" WS message already uses (`useSessionWebSockets.ts:97-100`'s `"split"` case), which rolls the stale segment's counters into `cumulative*` and resets `behaviorData` for the new segment, before any merge/replace runs. Nothing is deleted; the old segment's contribution is archived exactly the way an on-time split already archives it (into cumulative counters and its own exported CSV) — only the raw *event list* for the closed segment leaves `behaviorData`, which is the existing, intentional scope of `behaviorData` even in the fully-connected case.

`frames`/`slm` are untouched by this — they're genuinely whole-session, `handleSplit()` doesn't touch `frameData`, and their existing full-replace semantics remain correct after a missed split same as before.

**Documented limitation, not fixed:** a disconnect spanning *multiple* splits still converges structurally (`segmentNumber` jumps straight to current, `behaviorData` resets clean, nothing corrupts), but only rolls the last-known local counters into `cumulative*` once — a fully-missed intermediate segment's derived counts aren't separately re-added to the live UI's `cumulative*` fields. That segment's data isn't lost: it's already safely on disk as its own exported CSV and reflected in the backend's own `get_total_*` accessors (which is what the final export ZIP uses, not the frontend's `cumulative*` state — see reacher's `file.py` export comment on this). Only the live mid-session display could under-count by that segment's contribution in this specific multi-split-while-disconnected scenario. Narrower and lower-probability than the failure this PR fixes; syncing `cumulative*` from `get_total_*` on every recovery would close it but is a wider change than this finding asked for.

## Verification (round 2)

Re-ran after the round-2 fix, same baseline as above:
```
$ npm run lint
✖ 34 problems (0 errors, 34 warnings)

$ npx tsc -b
(no output — clean)
```

Still 34/0, still clean — no new warnings from the `handleSplit` integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYXvaZHknrwTpBnCRxHxb7